### PR TITLE
Add structured debug logging throughout the request pipeline

### DIFF
--- a/internal/graph/builder.go
+++ b/internal/graph/builder.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"log/slog"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
 	"github.com/yourorg/codewalker/internal/parser"
@@ -33,6 +34,9 @@ func Build(nodes []*parser.Node, src []byte, filePath string, omitRawSource bool
 		}
 		if !omitRawSource {
 			span.RawSource = n.Text
+			slog.Debug("step raw_source populated", "step_id", id, "src_len", len(n.Text))
+		} else {
+			slog.Debug("step raw_source omitted", "step_id", id)
 		}
 
 		step := &Step{
@@ -42,6 +46,7 @@ func Build(nodes []*parser.Node, src []byte, filePath string, omitRawSource bool
 			Source: span,
 		}
 		g.Add(step)
+		slog.Debug("step added", "step_id", id, "kind", step.Kind.String(), "start_line", n.StartLine, "end_line", n.EndLine)
 
 		// Build call edges from CallRefs.
 		for _, ref := range n.Calls {

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
@@ -31,6 +32,7 @@ func NewAnthropicProvider(apiKey string) *AnthropicProvider {
 // Narrate streams a narration for the given step.
 // Prompt assembly is delegated entirely to BuildMessages via StepContext.
 func (p *AnthropicProvider) Narrate(ctx context.Context, req NarrateRequest) (<-chan string, error) {
+	slog.Debug("narrate request", "language", req.Language, "effective_level", req.Level, "code_len", len(req.Code))
 	system, messages := BuildMessages(StepContext{
 		Language:        req.Language,
 		SymbolSignature: req.StepLabel,
@@ -115,6 +117,8 @@ func (p *AnthropicProvider) stream(ctx context.Context, system string, messages 
 
 	go func() {
 		defer close(ch)
+		tokenCount := 0
+		slog.Debug("anthropic stream started")
 		for s.Next() {
 			select {
 			case <-ctx.Done():
@@ -125,10 +129,12 @@ func (p *AnthropicProvider) stream(ctx context.Context, system string, messages 
 			switch e := event.AsAny().(type) {
 			case anthropic.ContentBlockDeltaEvent:
 				if delta, ok := e.Delta.AsAny().(anthropic.TextDelta); ok {
+					tokenCount++
 					ch <- delta.Text
 				}
 			}
 		}
+		slog.Debug("anthropic stream closed", "token_count", tokenCount)
 	}()
 
 	return ch, nil

--- a/server/navigate.go
+++ b/server/navigate.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log/slog"
 	"strings"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
@@ -53,6 +54,8 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 		return status.Errorf(codes.InvalidArgument, "navigation error: %v", navErr)
 	}
 
+	slog.Debug("navigated", "step_id", step.ID, "step_kind", step.Kind.String(), "step_label", step.Label)
+
 	crumbLabels := make([]string, 0, len(crumb))
 	for _, id := range crumb {
 		if st, ok := sess.Graph.Step(id); ok {
@@ -67,6 +70,7 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 	if code == "" && len(sess.Source) > 0 && step.Source != nil {
 		code = sliceSource(sess.Source, int(step.Source.StartLine), int(step.Source.EndLine))
 	}
+	slog.Debug("source resolved", "step_id", step.ID, "code_len", len(code))
 
 	tokens, err := s.provider.Narrate(ctx, llm.NarrateRequest{
 		Code:      code,
@@ -79,19 +83,23 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 	if err != nil {
 		return status.Errorf(codes.Internal, "narration error: %v", err)
 	}
+	slog.Debug("narration started", "step_id", step.ID)
 
+	tokenCount := 0
 	for token := range tokens {
 		select {
 		case <-ctx.Done():
 			return status.FromContextError(ctx.Err()).Err()
 		default:
 		}
+		tokenCount++
 		if err := stream.Send(&v1.NarrateEvent{
 			Event: &v1.NarrateEvent_Token{Token: &v1.NarrateToken{Text: token}},
 		}); err != nil {
 			return err
 		}
 	}
+	slog.Debug("narration complete", "step_id", step.ID, "token_count", tokenCount)
 
 	return stream.Send(&v1.NarrateEvent{
 		Event: &v1.NarrateEvent_Complete{

--- a/server/open_session.go
+++ b/server/open_session.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"log/slog"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
 	gogit "github.com/yourorg/codewalker/internal/git"
@@ -42,6 +43,7 @@ func (s *Server) OpenSession(req *v1.OpenSessionRequest, stream v1.CodeWalker_Op
 	if err != nil {
 		return status.Errorf(codes.NotFound, "cannot read %q at ref %q: %v", req.FilePath, req.Ref, err)
 	}
+	slog.Debug("file read", "file_path", req.FilePath, "ref", req.Ref, "src_len", len(src))
 
 	// --- Step 2: parse AST ---
 	if err := send(stream, progress("parsing AST", 20)); err != nil {
@@ -52,6 +54,7 @@ func (s *Server) OpenSession(req *v1.OpenSessionRequest, stream v1.CodeWalker_Op
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "parse error: %v", err)
 	}
+	slog.Debug("ast parsed", "language", language, "node_count", len(nodes))
 
 	// --- Step 3: build step graph ---
 	if err := send(stream, progress("building step graph", 40)); err != nil {
@@ -62,6 +65,7 @@ func (s *Server) OpenSession(req *v1.OpenSessionRequest, stream v1.CodeWalker_Op
 	if err != nil {
 		return status.Errorf(codes.Internal, "graph build error: %v", err)
 	}
+	slog.Debug("graph built", "step_count", g.Len(), "entry_step_id", g.EntryID)
 
 	// --- Step 4: extract glossary candidates ---
 	if err := send(stream, progress("extracting glossary", 65)); err != nil {
@@ -74,6 +78,7 @@ func (s *Server) OpenSession(req *v1.OpenSessionRequest, stream v1.CodeWalker_Op
 		Language: language,
 		Level:    effectiveLevel,
 	})
+	slog.Debug("glossary extracted", "term_count", len(glossaryCandidates))
 
 	// --- Step 5: create session ---
 	if err := send(stream, progress("creating session", 85)); err != nil {


### PR DESCRIPTION
All log entries use slog.Debug and are gated by the existing log-level handler in main.go, so they produce no output unless CODEWALKER_LOG_LEVEL=debug is set.

server/open_session.go:
  - After file read: file_path, ref, src_len
  - After AST parse: language, node_count
  - After graph build: step_count, entry_step_id
  - After glossary extraction: term_count

server/navigate.go:
  - After navigation resolves: step_id, step_kind, step_label
  - After source resolution: step_id, code_len (key signal — 0 means LLM gets nothing)
  - After Narrate returns channel: narration started
  - After token loop: token_count

internal/llm/anthropic.go — Narrate():
  - Before calling stream: language, effective_level, code_len

internal/llm/anthropic.go — stream() goroutine:
  - On goroutine start: anthropic stream started
  - On channel close: token_count

internal/graph/builder.go — buildNode():
  - After g.Add: step_id, kind, start_line, end_line
  - raw_source populated or omitted (with src_len when populated)

https://claude.ai/code/session_01XydCpj6KXGMC3m4dGjXNeZ