### PR TITLE
Log anthropic stream errors at error level after loop exits

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -134,7 +134,13 @@ func (p *AnthropicProvider) stream(ctx context.Context, system string, messages 
 				}
 			}
 		}
-		slog.Debug("anthropic stream closed", "token_count", tokenCount)
+		// s.Err() is the only way to observe stream errors — the error cannot be
+		// returned from stream() because this goroutine outlives that call.
+		if err := s.Err(); err != nil {
+			slog.Error("anthropic stream error", "error", err, "tokens_received", tokenCount)
+		} else {
+			slog.Debug("anthropic stream closed", "token_count", tokenCount)
+		}
 	}()
 
 	return ch, nil


### PR DESCRIPTION
s.Next() silently stops on error; s.Err() is the only way to observe it. The error cannot be returned from stream() since the goroutine outlives the call, so it is logged at slog.Error with tokens_received so it is impossible to miss in any log level. Successful close remains at Debug.

https://claude.ai/code/session_01XydCpj6KXGMC3m4dGjXNeZ