### PR TITLE
Add TTL-based session eviction

### DIFF
--- a/cmd/codewalker/main.go
+++ b/cmd/codewalker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net"
@@ -41,7 +42,13 @@ func run(cfg *config.Config) error {
 		return fmt.Errorf("unknown LLM provider %q", cfg.LLMProvider)
 	}
 
+	// Root context: cancelling it stops background goroutines (eviction, etc.).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	store := session.NewStore()
+	store.StartEviction(ctx, cfg.SessionTTL, cfg.EvictionInterval)
+
 	srv := server.New(store, provider, cfg.RepoRoot)
 
 	grpcServer := grpc.NewServer(
@@ -64,7 +71,12 @@ func run(cfg *config.Config) error {
 		return fmt.Errorf("listen %s: %w", addr, err)
 	}
 
-	slog.Info("codewalker listening", "addr", addr, "llm_provider", cfg.LLMProvider)
+	slog.Info("codewalker listening",
+		"addr", addr,
+		"llm_provider", cfg.LLMProvider,
+		"session_ttl", cfg.SessionTTL,
+		"eviction_interval", cfg.EvictionInterval,
+	)
 	return grpcServer.Serve(lis)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"time"
+)
 
 // Config holds all server configuration read from environment variables.
 type Config struct {
@@ -14,17 +17,23 @@ type Config struct {
 	LogLevel string
 	// LLMProvider selects the LLM backend.  "anthropic" in v1, "ollama" in v2.
 	LLMProvider string
+	// SessionTTL is how long a session may be idle before eviction.
+	SessionTTL time.Duration
+	// EvictionInterval is how often the eviction loop runs.
+	EvictionInterval time.Duration
 }
 
 // Load reads configuration from environment variables, applying defaults
 // where appropriate.
 func Load() *Config {
 	return &Config{
-		AnthropicAPIKey: os.Getenv("ANTHROPIC_API_KEY"),
-		Port:            envOr("CODEWALKER_PORT", "50051"),
-		RepoRoot:        envOr("CODEWALKER_REPO_ROOT", "/repos/target"),
-		LogLevel:        envOr("CODEWALKER_LOG_LEVEL", "info"),
-		LLMProvider:     envOr("CODEWALKER_LLM_PROVIDER", "anthropic"),
+		AnthropicAPIKey:  os.Getenv("ANTHROPIC_API_KEY"),
+		Port:             envOr("CODEWALKER_PORT", "50051"),
+		RepoRoot:         envOr("CODEWALKER_REPO_ROOT", "/repos/target"),
+		LogLevel:         envOr("CODEWALKER_LOG_LEVEL", "info"),
+		LLMProvider:      envOr("CODEWALKER_LLM_PROVIDER", "anthropic"),
+		SessionTTL:       parseDuration("CODEWALKER_SESSION_TTL", 2*time.Hour),
+		EvictionInterval: parseDuration("CODEWALKER_EVICTION_INTERVAL", 5*time.Minute),
 	}
 }
 
@@ -33,4 +42,16 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func parseDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"sync"
+	"time"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
 	"github.com/yourorg/codewalker/internal/graph"
@@ -22,6 +23,7 @@ type Session struct {
 	FilePath      string
 	RepoPath      string
 	Ref           string
+	LastAccessed  time.Time
 }
 
 // New creates a Session from an already-built graph.
@@ -38,6 +40,7 @@ func New(id string, g *graph.Graph, effectiveLevel int, language string, omitRaw
 		FilePath:      filePath,
 		RepoPath:      repoPath,
 		Ref:           ref,
+		LastAccessed:  time.Now(),
 	}
 }
 
@@ -65,6 +68,13 @@ func (s *Session) AllGlossaryTerms() []*v1.GlossaryTerm {
 		out = append(out, t)
 	}
 	return out
+}
+
+// Touch updates LastAccessed to now, resetting the eviction TTL clock.
+func (s *Session) Touch() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.LastAccessed = time.Now()
 }
 
 // Lock locks the session mutex for callers that need atomic multi-step operations.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 )
 
 // Store is an in-memory session registry.  v2 concern: persistence.
@@ -23,7 +26,7 @@ func (s *Store) Set(sess *Session) {
 	s.sessions[sess.ID] = sess
 }
 
-// Get retrieves a session by ID.
+// Get retrieves a session by ID and resets its eviction clock.
 func (s *Store) Get(id string) (*Session, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -31,6 +34,7 @@ func (s *Store) Get(id string) (*Session, error) {
 	if !ok {
 		return nil, fmt.Errorf("session %q not found", id)
 	}
+	sess.Touch()
 	return sess, nil
 }
 
@@ -57,4 +61,34 @@ func (s *Store) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.sessions)
+}
+
+// StartEviction launches a background goroutine that evicts sessions idle
+// longer than ttl, checked every interval. It stops when ctx is cancelled.
+func (s *Store) StartEviction(ctx context.Context, ttl time.Duration, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.evict(ttl)
+			}
+		}
+	}()
+}
+
+func (s *Store) evict(ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cutoff := time.Now().Add(-ttl)
+	for id, sess := range s.sessions {
+		if sess.LastAccessed.Before(cutoff) {
+			idle := time.Since(sess.LastAccessed)
+			slog.Debug("session evicted", "session_id", id, "idle_duration", idle)
+			delete(s.sessions, id)
+		}
+	}
 }


### PR DESCRIPTION
Session.LastAccessed is set on New() and updated by Touch(), which Get() calls on every access so any RPC resets the idle clock.

Store.StartEviction() launches a background goroutine that ticks at interval and calls evict(ttl), which holds the write lock, computes a cutoff time, and deletes any session whose LastAccessed is older than ttl. Removed sessions are logged at Debug with session_id and idle_duration. The goroutine stops cleanly when the provided context is cancelled.

config: CODEWALKER_SESSION_TTL (default 2h) and
CODEWALKER_EVICTION_INTERVAL (default 5m) are parsed as duration strings; malformed or non-positive values fall back to defaults.

main: a root context drives eviction; defer cancel() ensures the goroutine stops when run() returns. session_ttl and eviction_interval are logged at startup alongside the existing fields.

https://claude.ai/code/session_01XydCpj6KXGMC3m4dGjXNeZ