### PR TITLE
Add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/cmd/codewalker/main.go
+++ b/cmd/codewalker/main.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -77,7 +79,24 @@ func run(cfg *config.Config) error {
 		"session_ttl", cfg.SessionTTL,
 		"eviction_interval", cfg.EvictionInterval,
 	)
-	return grpcServer.Serve(lis)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- grpcServer.Serve(lis)
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case sig := <-quit:
+		slog.Info("shutdown signal received", "signal", sig)
+		grpcServer.GracefulStop() // waits for in-flight RPCs to complete
+		cancel()                  // stop background goroutines (eviction etc.)
+		return nil
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
+	}
 }
 
 func setupLogging(level string) {


### PR DESCRIPTION
Serve() runs in a goroutine and sends its error to a buffered channel. A signal channel watches SIGTERM and SIGINT. The select races the two:

- Signal received: log it, GracefulStop() (blocks until all in-flight RPCs finish and the listener is closed), then cancel() to stop the eviction goroutine. Order matters — server stops before context is cancelled so active streams can complete without new sessions being evicted mid-RPC.
- Serve() returns an error (listener failure, etc.): surface it as a fatal error so main() exits non-zero.

The defer cancel() on the root context remains as a safety net for any early-return error paths above the select.

https://claude.ai/code/session_01XydCpj6KXGMC3m4dGjXNeZ