### PR TITLE
Add gRPC health check protocol and Docker healthcheck

### DIFF
--- a/cmd/codewalker/main.go
+++ b/cmd/codewalker/main.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
@@ -65,6 +67,11 @@ func run(cfg *config.Config) error {
 	)
 
 	v1.RegisterCodeWalkerServer(grpcServer, srv)
+
+	healthSrv := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
+	healthSrv.SetServingStatus("codewalker.v1.CodeWalker", grpc_health_v1.HealthCheckResponse_SERVING)
+
 	reflection.Register(grpcServer)
 
 	addr := ":" + cfg.Port

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
+RUN GOBIN=/usr/local/bin go install github.com/grpc-ecosystem/grpc-health-probe@latest
+
 COPY . .
 RUN CGO_ENABLED=1 go build \
     -ldflags="-s -w -linkmode external -extldflags '-static'" \
@@ -16,6 +18,7 @@ RUN CGO_ENABLED=1 go build \
 FROM gcr.io/distroless/static
 
 COPY --from=builder /build/codewalker /codewalker
+COPY --from=builder /usr/local/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 
 EXPOSE 50051
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,3 +13,9 @@ services:
       - CODEWALKER_PORT=50051
       - CODEWALKER_LOG_LEVEL=${CODEWALKER_LOG_LEVEL:-info}
       - CODEWALKER_LLM_PROVIDER=${CODEWALKER_LLM_PROVIDER:-anthropic}
+    healthcheck:
+      test: ["CMD", "grpc-health-probe", "-addr=:50051"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s


### PR DESCRIPTION
cmd/codewalker/main.go:
  Register health.NewServer() alongside the main service. SetServingStatus
  marks codewalker.v1.CodeWalker as SERVING immediately on startup.
  The health server uses the same GracefulStop() lifecycle as the rest
  of the gRPC server.

deploy/Dockerfile:
  Builder stage installs grpc-health-probe to /usr/local/bin via
  go install. Runtime stage copies it from builder so the distroless
  image has it available for Docker health probes.

deploy/docker-compose.yml:
  Healthcheck runs grpc-health-probe -addr=:50051 every 10s with a 5s
  timeout, 3 retries, and a 5s start_period before the first check.

https://claude.ai/code/session_01XydCpj6KXGMC3m4dGjXNeZ