### PR TITLE
feat(forge): add ForgeHandler interface and registry

### DIFF
--- a/internal/forge/context.go
+++ b/internal/forge/context.go
@@ -1,0 +1,53 @@
+package forge
+
+// ForgeContext is the forge-agnostic representation of a parsed URL.
+// Produced by ForgeHandler.ParseURL and used throughout the review pipeline.
+type ForgeContext struct {
+	Kind          ForgeContextKind
+	Forge         string // e.g. "github", "gitlab"
+	Owner         string
+	Repo          string
+	BaseRef       string
+	HeadRef       string
+	PRNumber      int    // 0 if not a PR
+	PRTitle       string
+	PRDescription string
+	PRAuthor      string
+	URL           string // original URL
+}
+
+type ForgeContextKind int
+
+const (
+	ForgeContextKindUnspecified ForgeContextKind = iota
+	ForgeContextKindPR
+	ForgeContextKindCommit
+	ForgeContextKindComparison
+)
+
+// ReviewPayload is the result of FetchReview — everything needed to build
+// the review session step graph.
+type ReviewPayload struct {
+	Context *ForgeContext
+	Files   []*ReviewFile
+}
+
+// ReviewFile represents one changed file in a review.
+type ReviewFile struct {
+	Path         string
+	Language     string
+	ChangeKind   string // "ADDED" | "MODIFIED" | "DELETED" | "RENAMED"
+	OldPath      string // set for renames
+	Hunks        []*Hunk
+	LinesAdded   int
+	LinesRemoved int
+}
+
+// Hunk is a single contiguous block of changes within a file.
+type Hunk struct {
+	OldStart int
+	OldLines int
+	NewStart int
+	NewLines int
+	RawDiff  string
+}

--- a/internal/forge/handler.go
+++ b/internal/forge/handler.go
@@ -1,0 +1,30 @@
+package forge
+
+import "context"
+
+// ForgeHandler handles all forge-specific operations for a given host.
+// Implement this interface to add support for a new forge (GitLab, Gitea etc.).
+// Register implementations via Register() in an init() function.
+type ForgeHandler interface {
+	// Hosts returns the hostname patterns this handler claims.
+	// e.g. ["github.com"] or ["*.github.example.com"]
+	Hosts() []string
+
+	// ParseURL parses a forge URL into a forge-agnostic ForgeContext.
+	// Returns an error if the URL is not recognised or malformed.
+	ParseURL(rawURL string) (*ForgeContext, error)
+
+	// FetchReview fetches the full diff and metadata for a PR, commit,
+	// or branch comparison described by fc.
+	// token may be empty for public repositories.
+	FetchReview(ctx context.Context, fc *ForgeContext, token string) (*ReviewPayload, error)
+
+	// FetchFile fetches raw file content at a specific ref.
+	// Used to populate context_before and context_after on HunkSpan.
+	FetchFile(ctx context.Context, fc *ForgeContext, path, ref, token string) ([]byte, error)
+
+	// ResolveToken attempts to resolve a forge token from local credentials
+	// without user interaction (e.g. `gh auth token` for GitHub).
+	// Returns ("", nil) if no token is found — callers should then prompt the user.
+	ResolveToken(ctx context.Context) (string, error)
+}

--- a/internal/forge/registry.go
+++ b/internal/forge/registry.go
@@ -1,0 +1,43 @@
+package forge
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var (
+	mu       sync.RWMutex
+	handlers []ForgeHandler
+)
+
+// Register adds a ForgeHandler to the registry.
+// Call from an init() function in each forge implementation.
+func Register(h ForgeHandler) {
+	mu.Lock()
+	defer mu.Unlock()
+	handlers = append(handlers, h)
+}
+
+// Resolve returns the ForgeHandler whose Hosts() patterns match the given
+// hostname. Returns an error if no handler claims the host.
+func Resolve(host string) (ForgeHandler, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	for _, h := range handlers {
+		for _, pattern := range h.Hosts() {
+			if matchHost(pattern, host) {
+				return h, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no forge handler registered for host %q", host)
+}
+
+func matchHost(pattern, host string) bool {
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:]
+		return strings.HasSuffix(host, suffix)
+	}
+	return pattern == host
+}


### PR DESCRIPTION
## Summary

- Adds `ForgeHandler` interface defining the contract for forge implementations (ParseURL, FetchReview, FetchFile, ResolveToken)
- Adds forge-agnostic types: `ForgeContext`, `ReviewPayload`, `ReviewFile`, `Hunk`
- Adds thread-safe handler registry (`Register`/`Resolve`) with wildcard hostname matching
- Adds empty `internal/forge/forges/` directory (`.gitkeep`) for future forge implementations

Closes #11

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify `forge.Resolve("github.com")` returns `no forge handler registered for host "github.com"` (no handler registered yet — comes in issue 3)

https://claude.ai/code/session_01HPp6QUpSPRu5oV1jkEVbkn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPp6QUpSPRu5oV1jkEVbkn)_