### PR TITLE
feat(server): implement OpenReviewSession handler

### DIFF
--- a/internal/graph/walker.go
+++ b/internal/graph/walker.go
@@ -16,12 +16,13 @@ type Graph struct {
 
 // Step is the server-side representation of a single narration step.
 type Step struct {
-	ID      string
-	Label   string
-	Kind    v1.StepKind
-	Source  *v1.SourceSpan
-	Edges   []*v1.StepEdge
-	Visited bool
+	ID       string
+	Label    string
+	Kind     v1.StepKind
+	Source   *v1.SourceSpan
+	HunkSpan *v1.HunkSpan
+	Edges    []*v1.StepEdge
+	Visited  bool
 }
 
 // NewGraph creates an empty Graph.

--- a/internal/llm/prompts/narrate.go
+++ b/internal/llm/prompts/narrate.go
@@ -7,7 +7,20 @@ import (
 
 // Narrate returns the system + user messages for a step narration request.
 func Narrate(code, language, stepLabel, stepKind string, callChain []string, variables []string, level int) (system, user string) {
-	system = fmt.Sprintf(`You are a patient, expert code guide explaining %s code to a developer at experience level %d/10.
+	isDiff := strings.HasPrefix(strings.TrimSpace(code), "@@")
+
+	if isDiff {
+		system = fmt.Sprintf(`You are a patient, expert code reviewer explaining a diff to a developer at experience level %d/10.
+
+Narration style guidelines:
+- Level 1–3 (junior): Use simple analogies. Avoid jargon. Explain every construct and why it changed.
+- Level 4–6 (mid): Assume familiarity with basic constructs. Focus on intent and patterns behind the change.
+- Level 7–10 (senior): Be concise. Focus on design decisions, trade-offs, and non-obvious side effects.
+
+Format: Prose paragraphs only. No bullet lists. No markdown headers.
+Length: 2–4 paragraphs. Stop when the explanation is complete.`, level)
+	} else {
+		system = fmt.Sprintf(`You are a patient, expert code guide explaining %s code to a developer at experience level %d/10.
 
 Narration style guidelines:
 - Level 1–3 (junior): Use simple analogies. Avoid jargon. Explain every construct.
@@ -16,6 +29,7 @@ Narration style guidelines:
 
 Format: Prose paragraphs only. No bullet lists. No markdown headers.
 Length: 2–4 paragraphs. Stop when the explanation is complete.`, language, level)
+	}
 
 	var ctx strings.Builder
 	if len(callChain) > 0 {
@@ -29,12 +43,21 @@ Length: 2–4 paragraphs. Stop when the explanation is complete.`, language, lev
 		ctx.WriteString("\n")
 	}
 
-	user = fmt.Sprintf(`%sStep: %s (%s)
+	if isDiff {
+		user = fmt.Sprintf(`%sChange: %s (%s)
+
+Diff:
+%s
+
+Explain what this change does and why it might have been made.`, ctx.String(), stepLabel, stepKind, code)
+	} else {
+		user = fmt.Sprintf(`%sStep: %s (%s)
 
 Code:
 %s
 
 Narrate this step.`, ctx.String(), stepLabel, stepKind, code)
+	}
 
 	return system, user
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -17,6 +17,7 @@ type Session struct {
 	Walker        *graph.Walker
 	EffLevel      int // 1–10, from adaptation.go
 	Language      string
+	Kind          v1.SessionKind
 	Glossary      map[string]*v1.GlossaryTerm
 	OmitRawSource bool
 	Source        []byte
@@ -95,5 +96,6 @@ func (s *Session) Summary() *v1.SessionSummary {
 		Language:       s.Language,
 		CurrentStepId:  s.Walker.CurrentID(),
 		EffectiveLevel: uint32(s.EffLevel),
+		Kind:           s.Kind,
 	}
 }

--- a/server/navigate.go
+++ b/server/navigate.go
@@ -64,11 +64,13 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 	}
 
 	code := ""
-	if step.Source != nil {
+	if step.HunkSpan != nil {
+		code = step.HunkSpan.RawDiff
+	} else if step.Source != nil {
 		code = step.Source.RawSource
-	}
-	if code == "" && len(sess.Source) > 0 && step.Source != nil {
-		code = sliceSource(sess.Source, int(step.Source.StartLine), int(step.Source.EndLine))
+		if code == "" && len(sess.Source) > 0 {
+			code = sliceSource(sess.Source, int(step.Source.StartLine), int(step.Source.EndLine))
+		}
 	}
 	slog.Debug("source resolved", "step_id", step.ID, "code_len", len(code))
 

--- a/server/open_review_session.go
+++ b/server/open_review_session.go
@@ -1,0 +1,334 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	_ "github.com/yourorg/codewalker/internal/forge/forges"
+	"github.com/yourorg/codewalker/internal/graph"
+	"github.com/yourorg/codewalker/internal/llm"
+	"github.com/yourorg/codewalker/internal/session"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// OpenReviewSession implements CodeWalkerServer.OpenReviewSession.
+func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.CodeWalker_OpenReviewSessionServer) error {
+	ctx := stream.Context()
+
+	if req.Url == "" {
+		return status.Error(codes.InvalidArgument, "url is required")
+	}
+
+	// --- Step 1: parse URL ---
+	if err := send(stream, progress("parsing URL", 5)); err != nil {
+		return err
+	}
+
+	host, err := extractURLHost(req.Url)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid URL: %v", err)
+	}
+
+	handler, err := forge.Resolve(host)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "unsupported forge host %q: %v", host, err)
+	}
+
+	fc, err := handler.ParseURL(req.Url)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "malformed URL: %v", err)
+	}
+	slog.Debug("URL parsed", "forge", fc.Forge, "owner", fc.Owner, "repo", fc.Repo)
+
+	// --- Step 2: resolve token ---
+	if err := send(stream, progress("resolving token", 10)); err != nil {
+		return err
+	}
+
+	token := req.ForgeToken
+	if token == "" {
+		if resolved, resolveErr := handler.ResolveToken(ctx); resolveErr == nil {
+			token = resolved
+		}
+	}
+
+	// --- Step 3: fetch diff ---
+	if err := send(stream, progress("fetching diff", 20)); err != nil {
+		return err
+	}
+
+	payload, err := handler.FetchReview(ctx, fc, token)
+	if err != nil {
+		return forgeErrToStatus(err, "fetch diff")
+	}
+	slog.Debug("diff fetched", "file_count", len(payload.Files))
+
+	// Fetch file contents for hunk context (best-effort; errors are non-fatal).
+	fileLines := make(map[string][]string)
+	if fc.HeadRef != "" {
+		for _, f := range payload.Files {
+			if f.ChangeKind == "DELETED" {
+				continue
+			}
+			data, fetchErr := handler.FetchFile(ctx, fc, f.Path, fc.HeadRef, token)
+			if fetchErr != nil {
+				slog.Debug("skipping context fetch", "file", f.Path, "err", fetchErr)
+				continue
+			}
+			fileLines[f.Path] = strings.Split(string(data), "\n")
+		}
+	}
+
+	// --- Step 4: build step graph ---
+	if err := send(stream, progress("building step graph", 50)); err != nil {
+		return err
+	}
+
+	g, fileEntryStepIDs := buildHunkGraph(payload.Files, fileLines, req.OmitRawSource)
+	slog.Debug("hunk graph built", "step_count", g.Len(), "entry_step_id", g.EntryID)
+
+	// --- Step 5: extract glossary ---
+	if err := send(stream, progress("extracting glossary", 75)); err != nil {
+		return err
+	}
+
+	effectiveLevel := session.EffectiveLevel(req.ExperienceLevel)
+
+	var diffSample strings.Builder
+	if fc.PRDescription != "" {
+		diffSample.WriteString(fc.PRDescription)
+		diffSample.WriteString("\n\n")
+	}
+outer:
+	for _, f := range payload.Files {
+		for _, h := range f.Hunks {
+			diffSample.WriteString(h.RawDiff)
+			if diffSample.Len() > 4096 {
+				break outer
+			}
+		}
+	}
+
+	glossaryCandidates, _ := s.provider.ExtractGlossaryTerms(ctx, llm.GlossaryRequest{
+		Code:     diffSample.String(),
+		Language: "diff",
+		Level:    effectiveLevel,
+	})
+	slog.Debug("glossary extracted", "term_count", len(glossaryCandidates))
+
+	// --- Step 6: create session ---
+	if err := send(stream, progress("creating session", 90)); err != nil {
+		return err
+	}
+
+	sessID := newSessionID()
+	sess := session.New(sessID, g, effectiveLevel, "diff", req.OmitRawSource, nil, "", "", "")
+	sess.Kind = v1.SessionKind_SESSION_KIND_REVIEW
+
+	glossaryProto := make([]*v1.GlossaryTerm, 0, len(glossaryCandidates))
+	for _, c := range glossaryCandidates {
+		t := &v1.GlossaryTerm{
+			Term:   c.Term,
+			Kind:   termKindFromString(c.Kind),
+			StepId: g.EntryID,
+		}
+		sess.AddGlossaryTerm(t)
+		glossaryProto = append(glossaryProto, t)
+	}
+
+	s.store.Set(sess)
+
+	// --- Step 7: emit ReviewReady ---
+	forgeCtxProto := toProtoForgeContext(fc, payload.Files, fileEntryStepIDs)
+	steps := protoReviewSteps(g)
+
+	return send(stream, &v1.SessionEvent{
+		Event: &v1.SessionEvent_ReviewReady{
+			ReviewReady: &v1.ReviewReady{
+				SessionId:      sessID,
+				ForgeContext:   forgeCtxProto,
+				Steps:          steps,
+				Glossary:       glossaryProto,
+				TotalSteps:     uint32(g.Len()),
+				EntryStepId:    g.EntryID,
+				EffectiveLevel: uint32(effectiveLevel),
+			},
+		},
+	})
+}
+
+const hunkContextLines = 5
+
+func buildHunkGraph(files []*forge.ReviewFile, fileLines map[string][]string, omitRaw bool) (*graph.Graph, map[string]string) {
+	g := graph.NewGraph()
+	fileEntryStepIDs := make(map[string]string)
+
+	var prevStep *graph.Step
+
+	for _, file := range files {
+		lines := fileLines[file.Path]
+		for _, hunk := range file.Hunks {
+			id := fmt.Sprintf("hunk:%s:%d", file.Path, hunk.NewStart)
+
+			hunkSpan := &v1.HunkSpan{
+				FilePath: file.Path,
+				OldStart: uint32(hunk.OldStart),
+				OldLines: uint32(hunk.OldLines),
+				NewStart: uint32(hunk.NewStart),
+				NewLines: uint32(hunk.NewLines),
+			}
+			if !omitRaw {
+				hunkSpan.RawDiff = hunk.RawDiff
+			}
+			if len(lines) > 0 {
+				hunkSpan.ContextBefore = extractContextLines(lines, hunk.NewStart-hunkContextLines-1, hunk.NewStart-1)
+				hunkSpan.ContextAfter = extractContextLines(lines, hunk.NewStart+hunk.NewLines-1, hunk.NewStart+hunk.NewLines+hunkContextLines-1)
+			}
+
+			step := &graph.Step{
+				ID:       id,
+				Label:    fmt.Sprintf("%s:%d", file.Path, hunk.NewStart),
+				Kind:     v1.StepKind_STEP_KIND_HUNK,
+				HunkSpan: hunkSpan,
+			}
+			g.Add(step)
+
+			if _, ok := fileEntryStepIDs[file.Path]; !ok {
+				fileEntryStepIDs[file.Path] = id
+			}
+			if g.EntryID == "" {
+				g.EntryID = id
+			}
+
+			if prevStep != nil {
+				prevStep.Edges = append(prevStep.Edges, &v1.StepEdge{
+					TargetStepId: id,
+					Label:        v1.EdgeLabel_EDGE_LABEL_NEXT,
+					Navigable:    true,
+				})
+			}
+			prevStep = step
+		}
+	}
+
+	return g, fileEntryStepIDs
+}
+
+func extractContextLines(lines []string, start, end int) string {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if start >= end {
+		return ""
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+func protoReviewSteps(g *graph.Graph) []*v1.Step {
+	all := g.AllSteps()
+	out := make([]*v1.Step, 0, len(all))
+	for _, s := range all {
+		out = append(out, &v1.Step{
+			Id:       s.ID,
+			Label:    s.Label,
+			HunkSpan: s.HunkSpan,
+			Edges:    s.Edges,
+			Visited:  s.Visited,
+			Kind:     s.Kind,
+		})
+	}
+	return out
+}
+
+func toProtoForgeContext(fc *forge.ForgeContext, files []*forge.ReviewFile, fileEntryStepIDs map[string]string) *v1.ForgeContext {
+	protoFiles := make([]*v1.ReviewFile, 0, len(files))
+	for _, f := range files {
+		protoFiles = append(protoFiles, &v1.ReviewFile{
+			FilePath:     f.Path,
+			Language:     f.Language,
+			Change:       changeKindToProto(f.ChangeKind),
+			HunksTotal:   uint32(len(f.Hunks)),
+			LinesAdded:   uint32(f.LinesAdded),
+			LinesRemoved: uint32(f.LinesRemoved),
+			EntryStepId:  fileEntryStepIDs[f.Path],
+		})
+	}
+
+	return &v1.ForgeContext{
+		Kind:          forgeContextKindToProto(fc.Kind),
+		Forge:         fc.Forge,
+		Owner:         fc.Owner,
+		Repo:          fc.Repo,
+		BaseRef:       fc.BaseRef,
+		HeadRef:       fc.HeadRef,
+		PrNumber:      int32(fc.PRNumber),
+		PrTitle:       fc.PRTitle,
+		PrDescription: fc.PRDescription,
+		PrAuthor:      fc.PRAuthor,
+		Url:           fc.URL,
+		Files:         protoFiles,
+	}
+}
+
+func forgeContextKindToProto(k forge.ForgeContextKind) v1.ForgeContextKind {
+	switch k {
+	case forge.ForgeContextKindPR:
+		return v1.ForgeContextKind_FORGE_CONTEXT_KIND_PR
+	case forge.ForgeContextKindCommit:
+		return v1.ForgeContextKind_FORGE_CONTEXT_KIND_COMMIT
+	case forge.ForgeContextKindComparison:
+		return v1.ForgeContextKind_FORGE_CONTEXT_KIND_COMPARISON
+	default:
+		return v1.ForgeContextKind_FORGE_CONTEXT_KIND_UNSPECIFIED
+	}
+}
+
+func changeKindToProto(s string) v1.ChangeKind {
+	switch s {
+	case "ADDED":
+		return v1.ChangeKind_CHANGE_KIND_ADDED
+	case "DELETED":
+		return v1.ChangeKind_CHANGE_KIND_DELETED
+	case "RENAMED":
+		return v1.ChangeKind_CHANGE_KIND_RENAMED
+	default:
+		return v1.ChangeKind_CHANGE_KIND_MODIFIED
+	}
+}
+
+func forgeErrToStatus(err error, op string) error {
+	var fe *forge.Error
+	if errors.As(err, &fe) {
+		switch fe.Code {
+		case forge.ErrCodeAuthFailed:
+			return status.Errorf(codes.PermissionDenied, "%s: %v", op, err)
+		case forge.ErrCodeNotFound:
+			return status.Errorf(codes.NotFound, "%s: %v", op, err)
+		}
+	}
+	return status.Errorf(codes.Internal, "%s: %v", op, err)
+}
+
+func extractURLHost(rawURL string) (string, error) {
+	s := rawURL
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("no host in URL %q", rawURL)
+	}
+	return u.Host, nil
+}

--- a/server/open_review_session_test.go
+++ b/server/open_review_session_test.go
@@ -1,0 +1,297 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	"github.com/yourorg/codewalker/internal/llm"
+	"github.com/yourorg/codewalker/internal/session"
+	"github.com/yourorg/codewalker/server"
+	"google.golang.org/grpc/metadata"
+)
+
+// --- mock forge handler ---
+
+type mockForgeHandler struct{}
+
+func (m *mockForgeHandler) Hosts() []string { return []string{"test.example.com"} }
+
+func (m *mockForgeHandler) ParseURL(rawURL string) (*forge.ForgeContext, error) {
+	return &forge.ForgeContext{
+		Kind:          forge.ForgeContextKindPR,
+		Forge:         "mock",
+		Owner:         "owner",
+		Repo:          "repo",
+		PRNumber:      1,
+		PRTitle:       "Test PR",
+		PRDescription: "A test pull request",
+		PRAuthor:      "testuser",
+		BaseRef:       "main",
+		HeadRef:       "feature",
+		URL:           rawURL,
+	}, nil
+}
+
+func (m *mockForgeHandler) FetchReview(ctx context.Context, fc *forge.ForgeContext, token string) (*forge.ReviewPayload, error) {
+	return &forge.ReviewPayload{
+		Context: fc,
+		Files: []*forge.ReviewFile{
+			{
+				Path:       "auth/login.go",
+				Language:   "go",
+				ChangeKind: "MODIFIED",
+				Hunks: []*forge.Hunk{
+					{
+						OldStart: 42, OldLines: 3,
+						NewStart: 42, NewLines: 4,
+						RawDiff: "@@ -42,3 +42,4 @@\n context\n-old line\n+new line\n+added line\n context\n",
+					},
+					{
+						OldStart: 80, OldLines: 2,
+						NewStart: 81, NewLines: 2,
+						RawDiff: "@@ -80,2 +81,2 @@\n context\n-removed\n+replaced\n",
+					},
+				},
+				LinesAdded:   3,
+				LinesRemoved: 2,
+			},
+		},
+	}, nil
+}
+
+func (m *mockForgeHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext, path, ref, token string) ([]byte, error) {
+	return []byte("line 1\nline 2\nline 3\nline 4\nline 5\n"), nil
+}
+
+func (m *mockForgeHandler) ResolveToken(ctx context.Context) (string, error) {
+	return "mock-token", nil
+}
+
+func init() {
+	forge.Register(&mockForgeHandler{})
+}
+
+// --- mock LLM provider ---
+
+type mockProvider struct{}
+
+func (m *mockProvider) Narrate(_ context.Context, _ llm.NarrateRequest) (<-chan string, error) {
+	ch := make(chan string, 1)
+	ch <- "This change updates the authentication logic."
+	close(ch)
+	return ch, nil
+}
+
+func (m *mockProvider) Rephrase(_ context.Context, _ llm.RephraseRequest) (<-chan string, error) {
+	ch := make(chan string)
+	close(ch)
+	return ch, nil
+}
+
+func (m *mockProvider) SummarizeExternalCall(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (m *mockProvider) ExtractGlossaryTerms(_ context.Context, _ llm.GlossaryRequest) ([]llm.GlossaryCandidate, error) {
+	return []llm.GlossaryCandidate{
+		{Term: "authentication", Kind: "DOMAIN"},
+	}, nil
+}
+
+func (m *mockProvider) ExpandTerm(_ context.Context, _ llm.ExpandTermRequest) (<-chan string, error) {
+	ch := make(chan string)
+	close(ch)
+	return ch, nil
+}
+
+// --- mock gRPC stream for SessionEvent ---
+
+type mockSessionStream struct {
+	ctx    context.Context
+	events []*v1.SessionEvent
+}
+
+func (m *mockSessionStream) Send(e *v1.SessionEvent) error {
+	m.events = append(m.events, e)
+	return nil
+}
+func (m *mockSessionStream) Context() context.Context       { return m.ctx }
+func (m *mockSessionStream) SetHeader(metadata.MD) error   { return nil }
+func (m *mockSessionStream) SendHeader(metadata.MD) error  { return nil }
+func (m *mockSessionStream) SetTrailer(metadata.MD)        {}
+func (m *mockSessionStream) SendMsg(any) error             { return nil }
+func (m *mockSessionStream) RecvMsg(any) error             { return nil }
+
+// --- mock gRPC stream for NarrateEvent ---
+
+type mockNarrateStream struct {
+	ctx    context.Context
+	events []*v1.NarrateEvent
+}
+
+func (m *mockNarrateStream) Send(e *v1.NarrateEvent) error {
+	m.events = append(m.events, e)
+	return nil
+}
+func (m *mockNarrateStream) Context() context.Context       { return m.ctx }
+func (m *mockNarrateStream) SetHeader(metadata.MD) error   { return nil }
+func (m *mockNarrateStream) SendHeader(metadata.MD) error  { return nil }
+func (m *mockNarrateStream) SetTrailer(metadata.MD)        {}
+func (m *mockNarrateStream) SendMsg(any) error             { return nil }
+func (m *mockNarrateStream) RecvMsg(any) error             { return nil }
+
+// --- tests ---
+
+func TestOpenReviewSession(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	stream := &mockSessionStream{ctx: context.Background()}
+	err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+		Url: "https://test.example.com/owner/repo/pull/1",
+	}, stream)
+	if err != nil {
+		t.Fatalf("OpenReviewSession returned error: %v", err)
+	}
+
+	if len(stream.events) == 0 {
+		t.Fatal("expected at least one event")
+	}
+
+	// Last event must be ReviewReady.
+	last := stream.events[len(stream.events)-1]
+	rr := last.GetReviewReady()
+	if rr == nil {
+		t.Fatalf("last event is not ReviewReady: %T", last.Event)
+	}
+	if rr.SessionId == "" {
+		t.Error("expected non-empty session_id")
+	}
+	if rr.TotalSteps == 0 {
+		t.Error("expected total_steps > 0")
+	}
+	if rr.EntryStepId == "" {
+		t.Error("expected non-empty entry_step_id")
+	}
+	if rr.ForgeContext == nil {
+		t.Fatal("expected non-nil forge_context")
+	}
+	if rr.ForgeContext.Forge != "mock" {
+		t.Errorf("forge = %q, want %q", rr.ForgeContext.Forge, "mock")
+	}
+	if len(rr.Steps) == 0 {
+		t.Error("expected non-empty steps")
+	}
+	for _, step := range rr.Steps {
+		if step.HunkSpan == nil {
+			t.Errorf("step %q has nil hunk_span", step.Id)
+		}
+		if step.Kind != v1.StepKind_STEP_KIND_HUNK {
+			t.Errorf("step %q kind = %v, want STEP_KIND_HUNK", step.Id, step.Kind)
+		}
+	}
+
+	// Session should be stored and marked as review kind.
+	sess, err := store.Get(rr.SessionId)
+	if err != nil {
+		t.Fatalf("session not found: %v", err)
+	}
+	summary := sess.Summary()
+	if summary.Kind != v1.SessionKind_SESSION_KIND_REVIEW {
+		t.Errorf("session kind = %v, want SESSION_KIND_REVIEW", summary.Kind)
+	}
+}
+
+func TestOpenReviewSession_MissingURL(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	stream := &mockSessionStream{ctx: context.Background()}
+	err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{}, stream)
+	if err == nil {
+		t.Fatal("expected error for missing URL")
+	}
+}
+
+func TestOpenReviewSession_UnsupportedForge(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	stream := &mockSessionStream{ctx: context.Background()}
+	err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+		Url: "https://unknown-forge.example.org/owner/repo/pull/1",
+	}, stream)
+	if err == nil {
+		t.Fatal("expected error for unsupported forge")
+	}
+}
+
+func TestNavigateReviewSession(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	// Open a review session first.
+	sessionStream := &mockSessionStream{ctx: context.Background()}
+	if err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+		Url: "https://test.example.com/owner/repo/pull/1",
+	}, sessionStream); err != nil {
+		t.Fatalf("OpenReviewSession: %v", err)
+	}
+
+	rr := sessionStream.events[len(sessionStream.events)-1].GetReviewReady()
+	if rr == nil {
+		t.Fatal("no ReviewReady event")
+	}
+
+	// Navigate forward — should stream narration from the diff hunk.
+	narStream := &mockNarrateStream{ctx: context.Background()}
+	err := srv.Navigate(&v1.NavigateRequest{
+		SessionId: rr.SessionId,
+		Destination: &v1.NavigateRequest_Direction{
+			Direction: v1.SimpleDirection_SIMPLE_DIRECTION_FORWARD,
+		},
+	}, narStream)
+	if err != nil {
+		t.Fatalf("Navigate: %v", err)
+	}
+
+	if len(narStream.events) == 0 {
+		t.Fatal("expected narration events")
+	}
+	last := narStream.events[len(narStream.events)-1]
+	if last.GetComplete() == nil {
+		t.Errorf("last narrate event is not StepComplete: %T", last.Event)
+	}
+}
+
+func TestListSessionsReviewKind(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	sessionStream := &mockSessionStream{ctx: context.Background()}
+	if err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+		Url: "https://test.example.com/owner/repo/pull/1",
+	}, sessionStream); err != nil {
+		t.Fatalf("OpenReviewSession: %v", err)
+	}
+
+	resp, err := srv.ListSessions(context.Background(), &v1.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(resp.Sessions) == 0 {
+		t.Fatal("expected at least one session")
+	}
+	found := false
+	for _, s := range resp.Sessions {
+		if s.Kind == v1.SessionKind_SESSION_KIND_REVIEW {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("no session with SESSION_KIND_REVIEW in list")
+	}
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `server/open_review_session.go` implementing the `OpenReviewSession` gRPC handler: parses forge URLs, fetches PR/commit diffs via `ForgeHandler`, builds a flat sequential hunk step graph, extracts glossary terms, and emits `ReviewReady` with `ForgeContext` and per-file metadata
- Add `HunkSpan *v1.HunkSpan` to `graph.Step`; update `Navigate` to use `HunkSpan.RawDiff` as the narration source when the step is a diff hunk
- Add `Kind v1.SessionKind` to `session.Session`; `Summary()` now returns `SESSION_KIND_REVIEW` for review sessions; update narrate prompt to frame diff narration as "explain what this change does and why"

## Test plan

- [ ] `go test ./...` passes (all 5 new server tests + existing tests)
- [ ] `TestOpenReviewSession` — happy path: `ReviewReady` event with populated steps, forge context, and correct session kind
- [ ] `TestOpenReviewSession_MissingURL` — returns error for empty URL
- [ ] `TestOpenReviewSession_UnsupportedForge` — returns error for unknown host
- [ ] `TestNavigateReviewSession` — `Navigate` streams narration from hunk diff and emits `StepComplete`
- [ ] `TestListSessionsReviewKind` — `ListSessions` returns session with `SESSION_KIND_REVIEW`

Closes #13

https://claude.ai/code/session_0125RjGu6MFCycEjeJM7LMEE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125RjGu6MFCycEjeJM7LMEE)_