### PR TITLE
Add development prompts and contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ rpc GetVersion(GetVersionRequest) returns (GetVersionResponse)
 
 ---
 
+## Contributing
+
+Two prompts are available to streamline AI-assisted development on this project:
+
+- [Design session prompt](docs/DESIGN_PROMPT.md) — use this to start a Claude design session for planning features and reviewing PRs
+- [Claude Code prompt](docs/CLAUDE_CODE_PROMPT.md) — paste this before an issue body when starting a Claude Code implementation session
+
+The [briefing document](codewalker-briefing.md) is the source of truth for architectural decisions. Read it before making any structural changes.
+
+---
+
 ## Licence
 
 TBD

--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -350,3 +350,27 @@ Read from environment variables. No config files in v1.
 - When adding a new RPC or message (non-breaking), bump the minor version tag
 - When making a breaking proto change, bump `ProtoMajor` in the Dockerfile
   ldflags AND in the default value in `server/version.go`
+
+---
+
+## Development rules
+
+### Proto
+- Never run `protoc` directly — always use `make proto` to regenerate
+- Never edit files in `gen/` — they are always derived from `proto/`
+- `buf lint` must pass before submitting a PR
+- When adding a new RPC or message (non-breaking), bump the minor version tag
+- When making a breaking proto change, increment `ProtoMajor` in both `deploy/Dockerfile` ldflags and the default in `server/version.go`
+
+### Code
+- Prefer table-driven tests
+- All gRPC streaming handlers must check `ctx.Done()` in their token loops
+- Never log sensitive values — `forge_token` and `ANTHROPIC_API_KEY` must never appear in logs
+- New language handlers go in `internal/parser/languages/` and register via `init()`
+- New forge handlers go in `internal/forge/forges/` and register via `init()`
+- Mock implementations for testing go in `internal/llm/llmtest/` — never in production packages
+
+### Tooling
+- `make ci` — runs buf lint, go vet, go build, go test. Must pass before any PR
+- `make smoke-test` — runs a live end-to-end test against a running container. Requires `ANTHROPIC_API_KEY` and `REPO_PATH`. Do not run in CI
+- `make proto` — regenerates all Go stubs from proto. Run after any proto change

--- a/docs/CLAUDE_CODE_PROMPT.md
+++ b/docs/CLAUDE_CODE_PROMPT.md
@@ -1,0 +1,29 @@
+# Codewalker — Claude Code Session
+
+Before starting any work, read `codewalker-briefing.md` in full. It contains architectural decisions and coding rules that must be respected. If something you need to do contradicts the briefing, stop and ask rather than proceeding.
+
+Also read `README.md` to understand the current state of the project from a user perspective.
+
+## Branch and PR rules
+
+- Always create a new branch for each issue. Name it `claude/issue-{number}-{short-description}`
+- Always submit work as a PR — never commit directly to main
+- The PR description must accurately reflect every commit in the PR. If you add commits after the initial description, update the description to match
+- Before finalising the PR description, check it against all commits and flag any inconsistencies
+
+## Briefing and README updates
+
+- If your change introduces a new architectural decision, pattern, or operational detail that a future Claude Code session would need to know, append it to `codewalker-briefing.md` as part of the same PR
+- If your change affects how a developer installs, runs, or uses the service, update `README.md` as part of the same PR
+- Do not create separate PRs for documentation updates that belong with a feature
+
+## Before submitting the PR
+
+1. `make ci` passes
+2. PR description matches all commits
+3. `codewalker-briefing.md` updated if needed
+4. `README.md` updated if needed
+
+## The issue to address
+
+[paste issue body here]

--- a/docs/DESIGN_PROMPT.md
+++ b/docs/DESIGN_PROMPT.md
@@ -1,0 +1,42 @@
+# Codewalker — Design Session
+
+You are the design partner for Codewalker, an AI-powered code walkthrough and review service. Your role is to help design features, review pull requests, and generate instructions for Claude Code to implement.
+
+## The project
+
+Read `codewalker-briefing.md` from the repo for full context on architecture, decisions, and current state. The briefing is the source of truth — do not rely on your training data for project-specific details.
+
+## The repo
+
+https://github.com/snootbeestci/codewalker
+
+Raw file access: `raw.githubusercontent.com/snootbeestci/codewalker/main/{path}`
+
+## How we work
+
+1. Features and changes are designed in this chat
+2. Decisions are formalised as GitHub issues
+3. Claude Code implements the issues
+4. PRs come back here for review before merging
+
+## Issue format
+
+When writing GitHub issues, always format them as a single outer code block using `~~~` fences so the content can be copied with one click. Inner code examples use triple backtick fences. Every issue must include:
+
+- A clear title
+- Ordered implementation steps
+- Acceptance criteria
+- A **Briefing update** section if the change introduces anything a future Claude Code session needs to know — append it to `codewalker-briefing.md` as part of the PR
+- A **README update** section if the change affects how a developer installs, runs, or uses the service
+
+## PR review
+
+When reviewing a PR, always fetch and read the key changed files before approving. Flag:
+- Deviations from the proto contract
+- Anything that contradicts `codewalker-briefing.md`
+- Missing tests for new behaviour
+- Anything that would surprise a future developer reading the code
+
+## Continuity
+
+The briefing and README are the handoff documents between sessions. If a decision is made in this chat that future collaborators need to know, it must be captured in one of those documents before the session ends — not left only in the chat history.


### PR DESCRIPTION
This PR establishes structured guidance for AI-assisted development on Codewalker by introducing two specialized prompts and formalizing development rules in the briefing document.

## Changes

- **docs/DESIGN_PROMPT.md** — New prompt for design sessions that establishes the workflow for feature design, GitHub issue creation, and PR review. Defines the issue format with required sections (title, implementation steps, acceptance criteria, briefing/README updates) and PR review checklist.

- **docs/CLAUDE_CODE_PROMPT.md** — New prompt for Claude Code implementation sessions that specifies branch naming conventions (`claude/issue-{number}-{short-description}`), PR submission rules, and pre-submission checklist (`make ci`, description accuracy, documentation updates).

- **codewalker-briefing.md** — Formalized development rules into three sections:
  - **Proto**: Rules for protobuf changes, `make proto` usage, and versioning
  - **Code**: Patterns for tests, streaming handlers, logging, and handler registration
  - **Tooling**: Documents available make targets (`ci`, `smoke-test`, `proto`)

- **README.md** — Added "Contributing" section that directs developers to the two prompts and briefing document as the source of truth for architectural decisions.

## Rationale

These documents create a repeatable handoff protocol between design and implementation sessions, ensuring continuity across multiple AI-assisted development cycles. The briefing rules capture existing patterns and constraints that must be respected, while the prompts guide both design and implementation workflows.

https://claude.ai/code/session_01691cndueS9Qusa4DpCsJ6L