### PR TITLE
ci: add release workflow for Kotlin stubs and Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish-proto-stubs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Install C compiler
+        run: sudo apt-get install -y gcc
+
+      - name: Generate Kotlin stubs
+        run: buf generate --template buf.gen.kotlin.yaml
+
+      - name: Publish to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: gradle publish -p gradle
+
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    needs: publish-proto-stubs
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          tags: |
+            ghcr.io/snootbeestci/codewalker:${{ github.ref_name }}
+            ghcr.io/snootbeestci/codewalker:latest

--- a/buf.gen.kotlin.yaml
+++ b/buf.gen.kotlin.yaml
@@ -1,0 +1,7 @@
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/kotlin
+    out: gen/kotlin
+  - remote: buf.build/grpc/kotlin
+    out: gen/kotlin
+    opt: lite

--- a/gradle/publish.gradle.kts
+++ b/gradle/publish.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
 sourceSets {
     main {
-        kotlin.srcDirs("gen/kotlin")
+        kotlin.srcDirs("../gen/kotlin")
     }
 }
 

--- a/gradle/publish.gradle.kts
+++ b/gradle/publish.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    kotlin("jvm") version "1.9.0"
+    `maven-publish`
+}
+
+group = "com.github.snootbeestci"
+version = System.getenv("RELEASE_VERSION") ?: "dev"
+
+dependencies {
+    implementation("io.grpc:grpc-kotlin-stub:1.4.1")
+    implementation("io.grpc:grpc-protobuf-lite:1.60.0")
+    implementation("com.google.protobuf:protobuf-kotlin-lite:3.25.1")
+}
+
+sourceSets {
+    main {
+        kotlin.srcDirs("gen/kotlin")
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("stubs") {
+            artifactId = "codewalker-proto"
+            from(components["kotlin"])
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/snootbeestci/codewalker")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #21.

Adds a release workflow that triggers on versioned tag pushes (`v*`) and runs two sequential jobs:

- **publish-proto-stubs**: generates Kotlin gRPC stubs via `buf generate --template buf.gen.kotlin.yaml` and publishes them to GitHub Packages as `com.github.snootbeestci:codewalker-proto:{version}`
- **build-and-push-docker**: builds the Docker image and pushes it to `ghcr.io/snootbeestci/codewalker:{version}` and `:latest`

### Files added

| File | Purpose |
|---|---|
| `buf.gen.kotlin.yaml` | Separate buf generation config for Kotlin — keeps Kotlin out of the main `buf.gen.yaml` |
| `gradle/publish.gradle.kts` | Minimal Gradle build file for publishing the stubs as a Maven artifact |
| `.github/workflows/release.yml` | Two-job release workflow triggered on `v*` tag push |

### Acceptance criteria

- Pushing `v1.0.0` triggers the release workflow
- Kotlin stubs published as `com.github.snootbeestci:codewalker-proto:1.0.0`
- Docker image published as `ghcr.io/snootbeestci/codewalker:1.0.0` and `:latest`
- Existing `ci.yml` is unchanged — continues to run on every push and PR

## Test plan

- [ ] Push a `v*` tag to a fork and confirm both jobs complete successfully
- [ ] Confirm the Maven artifact appears in GitHub Packages under the expected coordinates
- [ ] Confirm the Docker image appears in GitHub Container Registry
- [ ] Confirm `ci.yml` still runs normally on a non-tag push

---
_Generated by [Claude Code](https://claude.ai/code/session_01QS1WdnRcqM2QqQ6NngBogx)_