### PR TITLE
Add Gradle build configuration and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Gradle build output and caches
+.gradle/
+build/
+gradle/.gradle/
+gradle/build/

--- a/gradle/settings.gradle.kts
+++ b/gradle/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "codewalker-proto-publish"


### PR DESCRIPTION
## Summary
Initialize Gradle build system configuration for the codewalker-proto-publish project.

## Key Changes
- Added `.gitignore` to exclude Gradle build artifacts and caches
  - Excludes `.gradle/` directories
  - Excludes `build/` output directories
  - Excludes gradle-specific build directories
- Added `gradle/settings.gradle.kts` to define the root project name as "codewalker-proto-publish"

## Details
This sets up the foundational Gradle configuration needed to build the project, establishing the project identity and ensuring build artifacts are not tracked in version control.

https://claude.ai/code/session_013cbNPHfhJHoDDoca5LKZEK