### PR TITLE
fix(release): upgrade Kotlin Gradle plugin to 2.0.21 for Gradle 9.x c…

### DIFF
--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "2.0.21"
     `maven-publish`
 }
 


### PR DESCRIPTION
…ompatibility

KGP 1.9.0 references HasConvention which was removed in Gradle 9.x. KGP 2.0+ no longer uses that class.

https://claude.ai/code/session_013cbNPHfhJHoDDoca5LKZEK