### PR TITLE
fix: ProtoMajor must be string for -X ldflags injection

### DIFF
--- a/server/version.go
+++ b/server/version.go
@@ -2,21 +2,24 @@ package server
 
 import (
 	"context"
+	"strconv"
 
 	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
 )
 
 // Version and ProtoMajor are set at build time via -ldflags.
 // Defaults are used when running outside of a release build.
+// ProtoMajor must be a string because -X ldflags can only inject string vars.
 var (
 	Version    = "dev"
-	ProtoMajor = uint32(1)
+	ProtoMajor = "1"
 )
 
 func (s *Server) GetVersion(_ context.Context, _ *v1.GetVersionRequest) (*v1.GetVersionResponse, error) {
+	major, _ := strconv.ParseUint(ProtoMajor, 10, 32)
 	return &v1.GetVersionResponse{
 		Version:                 Version,
-		ProtoMajor:              ProtoMajor,
+		ProtoMajor:              uint32(major),
 		MinCompatibleProtoMajor: 1,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- `server.ProtoMajor` was declared as `uint32`, but Go's `-X` ldflag can only set variables of type `string` — causing the Docker build to fail with `cannot set with -X: not a var of type string`
- Changed `ProtoMajor` to `string` with a default of `"1"`, and parse it to `uint32` in `GetVersion` using `strconv.ParseUint`
- No behaviour change: the RPC response still returns `ProtoMajor` as `uint32`; the Dockerfile ldflags are unchanged

## Test plan

- [x] `go vet ./...` passes
- [x] `CGO_ENABLED=1 go build ./...` passes (including with exact Dockerfile ldflags)
- [x] `CGO_ENABLED=1 go test ./...` passes (all existing tests green)

https://claude.ai/code/session_018TrY7qUKkTzEHRkaY7B1tb

---
_Generated by [Claude Code](https://claude.ai/code/session_018TrY7qUKkTzEHRkaY7B1tb)_