### PR TITLE
fix(release): strip leading v from tag when publishing Maven artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
           RELEASE_VERSION: ${{ github.ref_name }}
-        run: ./gradle/gradlew -p gradle publish
+        run: |
+          VERSION="${RELEASE_VERSION#v}"
+          RELEASE_VERSION="$VERSION" ./gradle/gradlew -p gradle publish
 
   build-and-push-docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `github.ref_name` for a tag like `v0.1.8` is the string `v0.1.8` (including the `v`)
- The release workflow was passing this directly as `RELEASE_VERSION` to Gradle, so the artifact was published at version `v0.1.8`
- Maven/Gradle convention has no leading `v` in version strings — the PhpStorm plugin (and any other JVM consumer) depends on `0.1.8`, not `v0.1.8`, so the artifact could never be resolved
- Fix: strip the leading `v` with `${RELEASE_VERSION#v}` in the publish step's run block before invoking Gradle
- Docker image tags are unaffected — they still use the full `github.ref_name` (e.g. `ghcr.io/snootbeestci/codewalker:v0.1.8`)

## Test plan

- [x] Confirmed the shell expression `${RELEASE_VERSION#v}` correctly strips a leading `v` (e.g. `v0.1.8` → `0.1.8`), and is a no-op if there is no leading `v`
- [ ] After merging, push a new `v*` tag and verify the GitHub Packages artifact appears at the bare version (e.g. `0.1.9`)

https://claude.ai/code/session_018TrY7qUKkTzEHRkaY7B1tb

---
_Generated by [Claude Code](https://claude.ai/code/session_018TrY7qUKkTzEHRkaY7B1tb)_