### PR TITLE
feat(release): auto-sync codewalker-proto on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
   sync-proto-repo:
     runs-on: ubuntu-latest
     needs: [publish-proto-stubs, build-and-push-docker]
+    environment: release
 
     steps:
       - name: Checkout codewalker (this repo)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Only commit if proto or stubs actually changed.
           if ! git diff --quiet || ! git diff --cached --quiet; then
             git add proto/codewalker/v1/codewalker.proto gen/kotlin
             git commit -m "chore: sync from codewalker ${{ github.ref_name }}"
             git push origin main
           fi
 
+          # Always tag — proto repo versions track backend versions even when
+          # the proto contract is unchanged. JitPack uses the tag to publish.
           git tag ${{ github.ref_name }}
           git push origin ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,47 @@ jobs:
           tags: |
             ghcr.io/snootbeestci/codewalker:${{ github.ref_name }}
             ghcr.io/snootbeestci/codewalker:latest
+
+  sync-proto-repo:
+    runs-on: ubuntu-latest
+    needs: [publish-proto-stubs, build-and-push-docker]
+
+    steps:
+      - name: Checkout codewalker (this repo)
+        uses: actions/checkout@v4
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Generate Kotlin stubs
+        run: buf generate --template buf.gen.kotlin.yaml
+
+      - name: Checkout codewalker-proto
+        uses: actions/checkout@v4
+        with:
+          repository: snootbeestci/codewalker-proto
+          token: ${{ secrets.PROTO_REPO_TOKEN }}
+          path: proto-repo
+
+      - name: Sync proto and stubs to codewalker-proto
+        run: |
+          cd proto-repo
+
+          mkdir -p proto/codewalker/v1
+          cp ../proto/codewalker/v1/codewalker.proto proto/codewalker/v1/codewalker.proto
+
+          rm -rf gen/kotlin
+          mkdir -p gen
+          cp -r ../gen/kotlin gen/kotlin
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            git add proto/codewalker/v1/codewalker.proto gen/kotlin
+            git commit -m "chore: sync from codewalker ${{ github.ref_name }}"
+            git push origin main
+          fi
+
+          git tag ${{ github.ref_name }}
+          git push origin ${{ github.ref_name }}

--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -357,6 +357,13 @@ Read from environment variables. No config files in v1.
 - Before tagging a release, run `make release-dry-run` to validate the Gradle
   publish setup locally. This catches build script issues without burning
   version numbers.
+- The `codewalker-proto` repo is derived. The release workflow syncs the
+  proto file and regenerated Kotlin stubs to it on each tagged release,
+  then tags the proto repo with the same version
+- Authentication uses the `PROTO_REPO_TOKEN` secret — a fine-grained PAT
+  with write access to `codewalker-proto` only
+- Never edit `codewalker-proto` directly. All proto changes happen in this
+  repo and propagate via the release workflow
 
 ---
 


### PR DESCRIPTION
## Summary

Makes `codewalker-proto` a fully derived artifact so it can never drift from the backend again. After this lands, every tagged backend release automatically pushes the latest proto file plus regenerated Kotlin stubs to `codewalker-proto` and tags it with the matching version.

This eliminates the class of bugs that produced the v0.3.0 stale stubs, the v0.3.1 / v0.3.2 empty artifacts, and the v0.3.3 manual fix.

### Changes

- **`.github/workflows/release.yml`** — new `sync-proto-repo` job that runs after `publish-proto-stubs` and `build-and-push-docker` both succeed. It regenerates Kotlin stubs, checks out `codewalker-proto` with `PROTO_REPO_TOKEN`, copies in the proto file + generated stubs, commits and pushes only when there's a diff, then tags the proto repo with the same `vX.Y.Z` as the backend release. Because of `needs:`, a failure earlier in the release leaves the proto repo untouched.
- **`codewalker-briefing.md`** — three new bullets under `## Release process` documenting the derived-repo model, the `PROTO_REPO_TOKEN` secret, and the rule that `codewalker-proto` is never edited by hand.

## To do next

These are out of scope for this PR — they need manual / cross-repo work:

- [ ] **Create the `PROTO_REPO_TOKEN` secret** in `snootbeestci/codewalker` settings. Generate a fine-grained PAT at https://github.com/settings/tokens?type=beta scoped to `snootbeestci/codewalker-proto` only, with `Contents: Read and write` and `Metadata: Read-only`. Without this secret the new job will fail at the `Checkout codewalker-proto` step.
- [ ] **Document PAT rotation** — note the expiry date somewhere durable so the token gets rotated before it lapses.
- [ ] **Separate PR against `codewalker-proto`**:
  - Update `README.md` with the "do not edit directly, this repo is derived" warning and the JitPack usage snippet.
  - Remove the existing CI drift check — it's no longer needed once humans don't edit the repo.
- [ ] **Cut `v0.3.4`** as the first tag after this merges to demonstrate the full flow end-to-end: proto repo receives a sync commit, gets tagged `v0.3.4`, JitPack builds it.

## Test plan

- [ ] Confirm `PROTO_REPO_TOKEN` secret exists in repo settings before tagging anything.
- [ ] Tag `v0.3.4` and verify:
  - [ ] `publish-proto-stubs` and `build-and-push-docker` succeed (existing behavior, unchanged).
  - [ ] `sync-proto-repo` runs, lands a commit on `codewalker-proto/main` with the proto file + `gen/kotlin` updates, and pushes a `v0.3.4` tag.
  - [ ] JitPack builds `com.github.snootbeestci:codewalker-proto:v0.3.4` successfully.
- [ ] Negative test (next time something legitimately fails): confirm a failure in `publish-proto-stubs` or `build-and-push-docker` skips the sync job and leaves `codewalker-proto` untouched.

https://claude.ai/code/session_01VKcqig752esdPJipwDB271

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKcqig752esdPJipwDB271)_