### PR TITLE
fix: consolidate Java and Kotlin stub generation into single output directory

### DIFF
--- a/buf.gen.kotlin.yaml
+++ b/buf.gen.kotlin.yaml
@@ -1,9 +1,9 @@
 version: v2
 plugins:
   - remote: buf.build/protocolbuffers/java:v28.3
-    out: gen/java
+    out: gen/kotlin
   - remote: buf.build/grpc/java:v1.68.1
-    out: gen/java
+    out: gen/kotlin
   - remote: buf.build/protocolbuffers/kotlin:v28.3
     out: gen/kotlin
   - remote: buf.build/grpc/kotlin:v1.4.1


### PR DESCRIPTION
## Summary

The `codewalker-proto` artifacts published via JitPack are missing the Java base classes for new types like `StepSummary`. The cause: `buf.gen.kotlin.yaml` emits Java stubs to `gen/java` and Kotlin stubs to `gen/kotlin`, but the release workflow's sync step (`.github/workflows/release.yml:105-114`) only copies `gen/kotlin` into the proto repo. The Java classes are generated but never shipped.

This change points all four plugins (Java, gRPC Java, Kotlin, gRPC Kotlin) at `gen/kotlin` so a single directory copy captures everything. Java and Kotlin plugins produce different file extensions (`.java` vs `.kt`), so they coexist without collision.

## Changes

- `buf.gen.kotlin.yaml`: switch the two Java plugin outputs from `gen/java` to `gen/kotlin`

## Test plan

- [ ] Run `rm -rf gen/ && buf generate --template buf.gen.kotlin.yaml` locally and confirm `gen/kotlin/codewalker/v1/` contains both `Codewalker.java` and `CodewalkerKt.kt`, and that `gen/java` is no longer created
- [ ] Tag a new release (e.g. `v0.3.5`) and verify the proto repo sync pushes a `gen/kotlin` directory containing both Java and Kotlin sources
- [ ] Confirm the resulting JitPack artifact resolves `StepSummary` from a consuming plugin's `build.gradle.kts`

_Note: `buf` was not available in the development environment, so local generation could not be verified before opening this PR._

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2JBVf11nm78FcoQVwrTwQ)_