### PR TITLE
fix(release): use git status to detect untracked files in proto sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Only commit if proto or stubs actually changed.
-          if ! git diff --quiet || ! git diff --cached --quiet; then
-            git add proto/codewalker/v1/codewalker.proto gen/kotlin
+          # Stage everything first so untracked new files are visible to the change check.
+          git add proto/codewalker/v1/codewalker.proto gen/kotlin
+
+          # Only commit if anything actually differs from HEAD.
+          if [ -n "$(git status --porcelain)" ]; then
             git commit -m "chore: sync from codewalker ${{ github.ref_name }}"
             git push origin main
           fi


### PR DESCRIPTION
## Summary

The release workflow's proto sync step used `git diff --quiet` to detect changes, but that only inspects tracked files. When `buf.gen.kotlin.yaml` produces new files (e.g. the Java base classes), they land as untracked files after `cp -r` and are invisible to the diff check — so the script falls through without committing even though the working tree contains new content.

This change reorders the logic to stage first, then detect changes via `git status --porcelain`, which reports tracked changes and untracked files alike.

## Changes

- `.github/workflows/release.yml`: in the *Sync proto and stubs to codewalker-proto* step, stage `proto/codewalker/v1/codewalker.proto` and `gen/kotlin` before the change check, then guard the commit with `[ -n "$(git status --porcelain)" ]`.

## Test plan

- [ ] Merge this PR
- [ ] Push tag `v0.3.6` and confirm the proto repo receives a commit containing both `Codewalker.java` and `CodewalkerKt.kt`
- [ ] Verify JitPack publishes a complete artifact for the new tag
- [ ] Confirm the plugin's `build.gradle.kts` can resolve `StepSummary` and other generated types from the new release

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV2AKpPh3JJpofBTLRbSyx)_