### PR TITLE
fix(release): force-add gen/kotlin since it is gitignored in proto repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Stage everything first so untracked new files are visible to the change check.
-          git add proto/codewalker/v1/codewalker.proto gen/kotlin
+          # Force-add gen/kotlin since it may be gitignored in the proto repo.
+          git add proto/codewalker/v1/codewalker.proto
+          git add -f gen/kotlin
 
           # Only commit if anything actually differs from HEAD.
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #48. After fixing the change-detection logic, the release run on the next tag failed with:

```
The following paths are ignored by one of your .gitignore files:
gen
hint: Use -f if you really want to add them.
Error: Process completed with exit code 1.
```

The `codewalker-proto` repo's `.gitignore` excludes `gen`, so `git add gen/kotlin` is silently refused (and exits non-zero). Generated stubs are exactly what we *do* want to publish to that repo, so we need to bypass the ignore rule.

## Changes

- `.github/workflows/release.yml`: split the staging step into two — `git add` for the proto file (normal), and `git add -f gen/kotlin` to force-add the generated stubs past the proto repo's `.gitignore`.

## Test plan

- [ ] Merge this PR
- [ ] Push a new tag (e.g. `v0.3.7`) and confirm the sync step completes without the ignored-path error
- [ ] Verify the proto repo receives a commit containing both `Codewalker.java` and `CodewalkerKt.kt`
- [ ] Verify JitPack publishes a complete artifact for the new tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV2AKpPh3JJpofBTLRbSyx)_