### PR TITLE
fix: generate lite protobuf stubs to match proto repo runtime dependencies

### DIFF
--- a/buf.gen.kotlin.yaml
+++ b/buf.gen.kotlin.yaml
@@ -2,9 +2,12 @@ version: v2
 plugins:
   - remote: buf.build/protocolbuffers/java:v28.3
     out: gen/kotlin
+    opt: lite
   - remote: buf.build/grpc/java:v1.68.1
     out: gen/kotlin
   - remote: buf.build/protocolbuffers/kotlin:v28.3
     out: gen/kotlin
+    opt: lite
   - remote: buf.build/grpc/kotlin:v1.4.1
     out: gen/kotlin
+    opt: lite


### PR DESCRIPTION
## Summary

Restores `opt: lite` on the Java, Kotlin, and grpc-kotlin generators in `buf.gen.kotlin.yaml`. The proto repo's `build.gradle.kts` depends on `protobuf-kotlin-lite` and `grpc-protobuf-lite`, but the generator config was producing non-lite stubs, causing JitPack builds to fail with `Cannot access 'com.google.protobuf.GeneratedMessage'`.

`grpc/java` is intentionally left without `opt: lite` — it does not support `lite` as a `--java_out` flag and produces gRPC service stubs that are independent of the protobuf runtime variant.

## Test plan

- [x] `make ci` passes locally (lint, build, test)
- [ ] After merge + new release tag, verify proto repo sync produces stubs matching its lite runtime dependencies
- [ ] Confirm JitPack builds the proto repo successfully against the new tag
- [ ] Confirm the plugin's `build.gradle.kts` can resolve and use the new artifact
