### PR TITLE
fix: remove grpc/java to eliminate non-lite runtime dependency conflict

### DIFF
--- a/buf.gen.kotlin.yaml
+++ b/buf.gen.kotlin.yaml
@@ -3,8 +3,6 @@ plugins:
   - remote: buf.build/protocolbuffers/java:v28.3
     out: gen/kotlin
     opt: lite
-  - remote: buf.build/grpc/java:v1.68.1
-    out: gen/kotlin
   - remote: buf.build/protocolbuffers/kotlin:v28.3
     out: gen/kotlin
     opt: lite


### PR DESCRIPTION
## Summary

Removes the `grpc/java` plugin from `buf.gen.kotlin.yaml`. The plugin's clients use the Kotlin coroutine gRPC stubs (`CodeWalkerGrpcKt.CodeWalkerCoroutineStub`), not the Java service stubs. The Java gRPC stubs require the non-lite `io.grpc.protobuf` runtime, which conflicts with the lite runtime used everywhere else.

The Java protobuf plugin still runs because the Kotlin DSL needs the Java message classes underneath. The gRPC service code is Kotlin-only — exactly what the plugin uses.

After this PR is merged, generated output will contain Java message classes (`Codewalker.java`) and Kotlin gRPC stubs (`CodeWalkerGrpcKt.kt`) but no `CodeWalkerGrpc.java`.

## Test plan

- [x] `make ci` passes locally
- [ ] After merge + new release tag, JitPack builds the proto repo successfully without the `io.grpc.protobuf` dependency conflict
- [ ] The plugin's existing references to `CodeWalkerGrpcKt.CodeWalkerCoroutineStub` resolve correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwZiPJhyQRH3yJ7Ao1fDYg)_