### PR TITLE
fix: restore grpc/java and remove lite mode for runtime compatibility

### DIFF
--- a/buf.gen.kotlin.yaml
+++ b/buf.gen.kotlin.yaml
@@ -2,10 +2,9 @@ version: v2
 plugins:
   - remote: buf.build/protocolbuffers/java:v28.3
     out: gen/kotlin
-    opt: lite
+  - remote: buf.build/grpc/java:v1.68.1
+    out: gen/kotlin
   - remote: buf.build/protocolbuffers/kotlin:v28.3
     out: gen/kotlin
-    opt: lite
   - remote: buf.build/grpc/kotlin:v1.4.1
     out: gen/kotlin
-    opt: lite


### PR DESCRIPTION
## Summary

Restores the `grpc/java` plugin in `buf.gen.kotlin.yaml` and removes the `opt: lite` flags from all Kotlin codegen plugins.

The Kotlin gRPC plugin generates stubs that delegate to the Java gRPC class for service descriptors, so removing `grpc/java` previously left the generated Kotlin code with unresolved references. The `opt: lite` flags are dropped because gRPC Java code uses `io.grpc.protobuf.*`, which is only available in the full protobuf runtime — lite mode causes downstream compilation failures.

This must be paired with a corresponding change in the `codewalker-proto` repo to use full protobuf and gRPC runtimes — otherwise the published artifact still won't compile.

## Test plan

- [x] `make ci` passes (buf lint, go vet, go build, go test)
- [ ] Verify Kotlin stubs compile against the full protobuf/gRPC runtimes once `codewalker-proto` is updated to match

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7Ws7q8wNgyCTEGZKDryWa)_