### PR TITLE
refactor: remove server-side forge token resolution

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -400,9 +400,11 @@ Read from environment variables. No config files in v1.
   at handler entry as a defence; clients are expected to send the
   canonical form so their own keying (e.g. token store keys) matches the
   wire form.
-- 403 responses from forges must preserve the forge's response body in
-  the gRPC status detail (truncated to ~500 chars). Clients use this to
-  distinguish bad-token errors from SSO-authorization-required errors.
+- 401 and 403 responses from forges must preserve the forge's response
+  body in the gRPC status detail (truncated to ~500 chars). Clients use
+  this to distinguish bad-token errors from SSO-authorization-required
+  errors, and to surface forge-specific guidance (e.g. "Bad credentials"
+  vs "token expired") without a second round trip.
 - When in doubt about a design decision, check this document before asking. If it is not covered here, ask the user
 
 ### Tooling

--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -274,11 +274,10 @@ existing code.
 - `ForgeHandler` is an interface in `internal/forge/handler.go`, registered
   via init() in `internal/forge/forges/`. Same pattern as LanguageHandler.
 - GitHub is the v1 forge. GitLab, Gitea, Bitbucket are additive.
-- Token resolution order (plugin-side):
-    1. forge_token field on OpenReviewSessionRequest if supplied by client
-    2. handler.ResolveToken() — checks gh CLI silently
-    3. Empty string — public repo mode
-  The backend never stores tokens beyond the session lifetime. Never log them.
+- Token resolution is the client's responsibility. The server treats
+  `forge_token` as an opaque caller-supplied value — empty means
+  unauthenticated (public repo access only). The backend never stores
+  tokens beyond the request lifetime. Never log them.
 - Once open, review sessions use the same Navigate/Rephrase/ExpandTerm RPCs
   as walkthrough sessions. The step graph contains STEP_KIND_HUNK steps
   instead of AST steps.
@@ -393,6 +392,17 @@ Read from environment variables. No config files in v1.
   step proceeds with `summary = nil` and a debug log
 - Summary fields are always populated with "—" for non-applicable values rather
   than being absent. This guarantees clients can render a consistent layout
+- Forge handlers must not perform credential lookups. Tokens come from the
+  request only. Anything that reads ambient credentials (env vars, config
+  files, CLI tools) belongs in the client.
+- Host strings on RPC requests are normalised: bare hostname, lowercase,
+  no scheme, no trailing slash. The server applies `forge.NormalizeHost`
+  at handler entry as a defence; clients are expected to send the
+  canonical form so their own keying (e.g. token store keys) matches the
+  wire form.
+- 403 responses from forges must preserve the forge's response body in
+  the gRPC status detail (truncated to ~500 chars). Clients use this to
+  distinguish bad-token errors from SSO-authorization-required errors.
 - When in doubt about a design decision, check this document before asking. If it is not covered here, ask the user
 
 ### Tooling

--- a/internal/forge/error.go
+++ b/internal/forge/error.go
@@ -10,9 +10,16 @@ const (
 )
 
 // Error is a typed forge error that carries a machine-readable code.
+//
+// Detail optionally carries the forge's raw response body. It is used for 403
+// responses so clients can distinguish a bad token from an organization-level
+// SSO authorization requirement (e.g. GitHub Enterprise SAML SSO returns 403
+// with a body explaining the missing authorization). Truncated to ~500 chars
+// at the source.
 type Error struct {
-	Code ErrCode
-	Msg  string
+	Code   ErrCode
+	Msg    string
+	Detail string
 }
 
 func (e *Error) Error() string { return e.Msg }

--- a/internal/forge/forges/github.go
+++ b/internal/forge/forges/github.go
@@ -5,9 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -114,14 +114,6 @@ func (g *githubHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext, p
 	return data, nil
 }
 
-func (g *githubHandler) ResolveToken(ctx context.Context) (string, error) {
-	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
-	if err != nil {
-		return "", nil
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
 // --- GitHub API types ---
 
 type ghPR struct {
@@ -171,12 +163,23 @@ func (g *githubHandler) apiDo(ctx context.Context, apiURL, token string) (*http.
 	return http.DefaultClient.Do(req)
 }
 
+// errBodyMaxBytes caps how much of a forge response body we propagate into the
+// gRPC status detail. GitHub Enterprise SSO error bodies are short prose;
+// 500 bytes is enough to convey the cause without leaking large payloads.
+const errBodyMaxBytes = 500
+
 func checkStatus(resp *http.Response) error {
 	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden:
+	case http.StatusUnauthorized:
 		return &forge.Error{
 			Code: forge.ErrCodeAuthFailed,
 			Msg:  fmt.Sprintf("GitHub API auth failed (%s)", resp.Status),
+		}
+	case http.StatusForbidden:
+		return &forge.Error{
+			Code:   forge.ErrCodeAuthFailed,
+			Msg:    fmt.Sprintf("GitHub API auth failed (%s)", resp.Status),
+			Detail: readBodySnippet(resp.Body),
 		}
 	case http.StatusNotFound:
 		return &forge.Error{
@@ -188,6 +191,16 @@ func checkStatus(resp *http.Response) error {
 		return fmt.Errorf("GitHub API error: %s", resp.Status)
 	}
 	return nil
+}
+
+// readBodySnippet reads up to errBodyMaxBytes from r and returns the result
+// as a trimmed string. Errors are swallowed — a missing body is acceptable.
+func readBodySnippet(r io.Reader) string {
+	buf, err := io.ReadAll(io.LimitReader(r, errBodyMaxBytes))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(buf))
 }
 
 func (g *githubHandler) fetchPRReview(ctx context.Context, fc *forge.ForgeContext, token string) (*forge.ReviewPayload, error) {

--- a/internal/forge/forges/github.go
+++ b/internal/forge/forges/github.go
@@ -195,6 +195,10 @@ func checkStatus(resp *http.Response) error {
 
 // readBodySnippet reads up to errBodyMaxBytes from r and returns the result
 // as a trimmed string. Errors are swallowed — a missing body is acceptable.
+//
+// This function does NOT close r. The caller of apiDo owns the response
+// body and must close it via defer resp.Body.Close() at the call site.
+// Closing here would be redundant at best and a double-close at worst.
 func readBodySnippet(r io.Reader) string {
 	buf, err := io.ReadAll(io.LimitReader(r, errBodyMaxBytes))
 	if err != nil {

--- a/internal/forge/forges/github.go
+++ b/internal/forge/forges/github.go
@@ -170,12 +170,7 @@ const errBodyMaxBytes = 500
 
 func checkStatus(resp *http.Response) error {
 	switch resp.StatusCode {
-	case http.StatusUnauthorized:
-		return &forge.Error{
-			Code: forge.ErrCodeAuthFailed,
-			Msg:  fmt.Sprintf("GitHub API auth failed (%s)", resp.Status),
-		}
-	case http.StatusForbidden:
+	case http.StatusUnauthorized, http.StatusForbidden:
 		return &forge.Error{
 			Code:   forge.ErrCodeAuthFailed,
 			Msg:    fmt.Sprintf("GitHub API auth failed (%s)", resp.Status),

--- a/internal/forge/handler.go
+++ b/internal/forge/handler.go
@@ -22,9 +22,4 @@ type ForgeHandler interface {
 	// FetchFile fetches raw file content at a specific ref.
 	// Used to populate context_before and context_after on HunkSpan.
 	FetchFile(ctx context.Context, fc *ForgeContext, path, ref, token string) ([]byte, error)
-
-	// ResolveToken attempts to resolve a forge token from local credentials
-	// without user interaction (e.g. `gh auth token` for GitHub).
-	// Returns ("", nil) if no token is found — callers should then prompt the user.
-	ResolveToken(ctx context.Context) (string, error)
 }

--- a/internal/forge/host.go
+++ b/internal/forge/host.go
@@ -1,0 +1,16 @@
+package forge
+
+import "strings"
+
+// NormalizeHost canonicalises a forge host string so that server-side keying
+// and forge handler dispatch agree with the client. Clients are expected to
+// send the canonical form; this is a defensive normalisation applied at
+// handler entry. The rules are documented in the briefing — see the
+// "Host strings on RPC requests" bullet under Development rules → Code.
+func NormalizeHost(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimSuffix(s, "/")
+	return strings.ToLower(s)
+}

--- a/internal/forge/host_test.go
+++ b/internal/forge/host_test.go
@@ -1,0 +1,35 @@
+package forge
+
+import "testing"
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare hostname", "github.com", "github.com"},
+		{"https scheme", "https://github.com", "github.com"},
+		{"http scheme", "http://github.com", "github.com"},
+		{"trailing slash", "github.com/", "github.com"},
+		{"scheme and trailing slash", "https://github.com/", "github.com"},
+		{"mixed case", "GitHub.com", "github.com"},
+		{"upper case", "GITHUB.COM", "github.com"},
+		{"leading whitespace", "  github.com", "github.com"},
+		{"trailing whitespace", "github.com  ", "github.com"},
+		{"surrounding whitespace", "  github.com  ", "github.com"},
+		{"GHE-style subdomain", "github.mycompany.com", "github.mycompany.com"},
+		{"GHE with scheme and case", "https://GitHub.MyCompany.Com", "github.mycompany.com"},
+		{"non-standard port", "gitea.internal:3000", "gitea.internal:3000"},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeHost(tc.in)
+			if got != tc.want {
+				t.Errorf("NormalizeHost(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/forge_err_test.go
+++ b/server/forge_err_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/yourorg/codewalker/internal/forge"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestForgeErrToStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantCode     codes.Code
+		wantContains []string
+	}{
+		{
+			name:         "auth failed without detail",
+			err:          &forge.Error{Code: forge.ErrCodeAuthFailed, Msg: "GitHub API auth failed (401 Unauthorized)"},
+			wantCode:     codes.PermissionDenied,
+			wantContains: []string{"GitHub API auth failed"},
+		},
+		{
+			name: "403 with SAML SSO body",
+			err: &forge.Error{
+				Code:   forge.ErrCodeAuthFailed,
+				Msg:    "GitHub API auth failed (403 Forbidden)",
+				Detail: `{"message":"Resource protected by organization SAML enforcement"}`,
+			},
+			wantCode:     codes.PermissionDenied,
+			wantContains: []string{"GitHub API auth failed", "Resource protected by organization SAML enforcement"},
+		},
+		{
+			name:         "not found",
+			err:          &forge.Error{Code: forge.ErrCodeNotFound, Msg: "GitHub API not found (404 Not Found)"},
+			wantCode:     codes.NotFound,
+			wantContains: []string{"not found"},
+		},
+		{
+			name:         "unknown error",
+			err:          errors.New("network broke"),
+			wantCode:     codes.Internal,
+			wantContains: []string{"network broke"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, ok := status.FromError(forgeErrToStatus(tc.err, "fetch diff"))
+			if !ok {
+				t.Fatalf("not a gRPC status: %v", tc.err)
+			}
+			if st.Code() != tc.wantCode {
+				t.Errorf("code = %v, want %v", st.Code(), tc.wantCode)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(st.Message(), want) {
+					t.Errorf("status message missing %q: got %q", want, st.Message())
+				}
+			}
+		})
+	}
+}

--- a/server/forge_err_test.go
+++ b/server/forge_err_test.go
@@ -18,10 +18,14 @@ func TestForgeErrToStatus(t *testing.T) {
 		wantContains []string
 	}{
 		{
-			name:         "auth failed without detail",
-			err:          &forge.Error{Code: forge.ErrCodeAuthFailed, Msg: "GitHub API auth failed (401 Unauthorized)"},
+			name: "401 auth failed with detail",
+			err: &forge.Error{
+				Code:   forge.ErrCodeAuthFailed,
+				Msg:    "GitHub API auth failed (401 Unauthorized)",
+				Detail: `{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`,
+			},
 			wantCode:     codes.PermissionDenied,
-			wantContains: []string{"GitHub API auth failed"},
+			wantContains: []string{"GitHub API auth failed", "Bad credentials"},
 		},
 		{
 			name: "403 with SAML SSO body",

--- a/server/open_review_session.go
+++ b/server/open_review_session.go
@@ -35,6 +35,7 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid URL: %v", err)
 	}
+	host = forge.NormalizeHost(host)
 
 	handler, err := forge.Resolve(host)
 	if err != nil {
@@ -47,19 +48,11 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 	}
 	slog.Debug("URL parsed", "forge", fc.Forge, "owner", fc.Owner, "repo", fc.Repo)
 
-	// --- Step 2: resolve token ---
-	if err := send(stream, progress("resolving token", 10)); err != nil {
-		return err
-	}
-
+	// Token is the caller's responsibility. Empty means unauthenticated; the
+	// forge will return PermissionDenied for private resources.
 	token := req.ForgeToken
-	if token == "" {
-		if resolved, resolveErr := handler.ResolveToken(ctx); resolveErr == nil {
-			token = resolved
-		}
-	}
 
-	// --- Step 3: fetch diff ---
+	// --- Step 2: fetch diff ---
 	if err := send(stream, progress("fetching diff", 20)); err != nil {
 		return err
 	}
@@ -92,7 +85,7 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 		}
 	}
 
-	// --- Step 4: build step graph ---
+	// --- Step 3: build step graph ---
 	if err := send(stream, progress("building step graph", 50)); err != nil {
 		return err
 	}
@@ -100,7 +93,7 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 	g, fileEntryStepIDs := buildHunkGraph(payload.Files, fileLines, req.OmitRawSource)
 	slog.Debug("hunk graph built", "step_count", g.Len(), "entry_step_id", g.EntryID)
 
-	// --- Step 5: extract glossary ---
+	// --- Step 4: extract glossary ---
 	if err := send(stream, progress("extracting glossary", 75)); err != nil {
 		return err
 	}
@@ -129,7 +122,7 @@ outer:
 	})
 	slog.Debug("glossary extracted", "term_count", len(glossaryCandidates))
 
-	// --- Step 6: create session ---
+	// --- Step 5: create session ---
 	if err := send(stream, progress("creating session", 90)); err != nil {
 		return err
 	}
@@ -151,7 +144,7 @@ outer:
 
 	s.store.Set(sess)
 
-	// --- Step 7: emit ReviewReady ---
+	// --- Step 6: emit ReviewReady ---
 	forgeCtxProto := toProtoForgeContext(fc, payload.Files, fileEntryStepIDs)
 	steps := protoReviewSteps(g)
 
@@ -317,6 +310,9 @@ func forgeErrToStatus(err error, op string) error {
 	if errors.As(err, &fe) {
 		switch fe.Code {
 		case forge.ErrCodeAuthFailed:
+			if fe.Detail != "" {
+				return status.Errorf(codes.PermissionDenied, "%s: %v: %s", op, err, fe.Detail)
+			}
 			return status.Errorf(codes.PermissionDenied, "%s: %v", op, err)
 		case forge.ErrCodeNotFound:
 			return status.Errorf(codes.NotFound, "%s: %v", op, err)

--- a/server/open_review_session_ordering_test.go
+++ b/server/open_review_session_ordering_test.go
@@ -51,8 +51,6 @@ func (m *multiFileForgeHandler) FetchFile(_ context.Context, _ *forge.ForgeConte
 	return []byte("line\n"), nil
 }
 
-func (m *multiFileForgeHandler) ResolveToken(_ context.Context) (string, error) { return "", nil }
-
 func init() {
 	forge.Register(&multiFileForgeHandler{})
 }

--- a/server/open_review_session_test.go
+++ b/server/open_review_session_test.go
@@ -65,10 +65,6 @@ func (m *mockForgeHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext
 	return []byte("line 1\nline 2\nline 3\nline 4\nline 5\n"), nil
 }
 
-func (m *mockForgeHandler) ResolveToken(ctx context.Context) (string, error) {
-	return "mock-token", nil
-}
-
 func init() {
 	forge.Register(&mockForgeHandler{})
 }


### PR DESCRIPTION
Closes #54.

## Commits

1. `refactor: remove server-side forge token resolution`
2. `docs: clarify response body ownership in readBodySnippet`
3. `feat: capture forge response body on 401 as well as 403`

## Summary

Token resolution moves entirely to the client. The server now treats `forge_token` as an opaque caller-supplied value:

- non-empty → used verbatim
- empty → unauthenticated request (public resources succeed; private return `PermissionDenied`)

There is no server-side fallback. The `ResolveToken` cascade and the GitHub `gh auth token` shell-out are gone — that convenience belongs in clients (per-host) where it can correctly key by hostname.

## Changes

**Interface and handler**
- Drop `ResolveToken(ctx) (string, error)` from `ForgeHandler` (`internal/forge/handler.go`)
- Remove the `gh` CLI shell-out and its `os/exec` import from `internal/forge/forges/github.go`

**Host normalisation**
- New `forge.NormalizeHost` helper in `internal/forge/host.go`: trims whitespace, strips `http(s)://`, strips trailing `/`, lowercases
- Table-driven tests in `internal/forge/host_test.go` cover bare hostname, with scheme, trailing slash, mixed case, whitespace, GHE-style subdomain, non-standard port
- Applied at the entry of `OpenReviewSession` — `ListPullRequests` (issue #43) is not yet merged, so its handler will be authored against the same rule

**Token plumbing**
- `OpenReviewSession` (`server/open_review_session.go`) passes `req.ForgeToken` straight through to the forge handler — no resolution, no fallback. The progress event for "resolving token" is dropped; remaining steps are renumbered

**401/403 detail propagation**
- `forge.Error` gains a `Detail` field for the forge's response body
- `github.go` `checkStatus` reads up to 500 bytes from the response body on **both 401 and 403** and stuffs it into `Detail`. The two cases share the same arm of the switch
- `forgeErrToStatus` includes `Detail` in the gRPC status message when present, matching the in-message detail pattern already used by other server handlers (no `status.WithDetails` introduction)
- Token never appears in any error path

**Body ownership doc (commit 2)**
- Expanded the `readBodySnippet` doc comment to make explicit that it does NOT close `r` — the caller of `apiDo` owns the body and closes it via `defer resp.Body.Close()` at the call site. Audited all five `apiDo` call sites: every one is followed by `defer resp.Body.Close()` before `checkStatus(resp)`. No code change.

**Tests**
- Remove `ResolveToken` from mock forge handlers (`server/open_review_session_test.go`, `server/open_review_session_ordering_test.go`)
- `server/forge_err_test.go` covers `forgeErrToStatus`: 401 with `"Bad credentials"` body, 403 with SAML SSO body, 404, generic error

**Briefing**
- Replace the token-cascade bullet under Review sessions → Key design decisions
- Add three new bullets under Development rules → Code: forge handlers must not look up credentials, host strings are normalised, **401 and 403** detail is preserved with motivating examples ("Bad credentials" vs "token expired", SSO-required vs bad-token)

## Verification

- `make ci` passes (buf lint, go vet, go build, go test)
- README spot-checked — Quickstart still lists only `ANTHROPIC_API_KEY` and `REPO_PATH`; no `gh` mention exists or is added

## Test plan

- [x] `make ci` green
- [x] `forge.NormalizeHost` round-trips canonical inputs and normalises every documented variant
- [x] `forgeErrToStatus` preserves 401 and 403 bodies in the status message
- [x] Mock forge handlers compile and existing review session tests still pass without `ResolveToken`
- [ ] Manual: hit a private repo with empty `forge_token` → expect `PermissionDenied`
- [ ] Manual: hit a SAML-protected GHE repo with a non-SSO-authorized token → expect `PermissionDenied` with the SSO message in the status detail
- [ ] Manual: hit any repo with a malformed `forge_token` → expect `PermissionDenied` with `"Bad credentials"` in the status detail

https://claude.ai/code/session_01Mrf9BG3SnMY4KfohKckHr9