### PR TITLE
feat: trim trailing dot in forge.NormalizeHost

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -396,10 +396,10 @@ Read from environment variables. No config files in v1.
   request only. Anything that reads ambient credentials (env vars, config
   files, CLI tools) belongs in the client.
 - Host strings on RPC requests are normalised: bare hostname, lowercase,
-  no scheme, no trailing slash. The server applies `forge.NormalizeHost`
-  at handler entry as a defence; clients are expected to send the
-  canonical form so their own keying (e.g. token store keys) matches the
-  wire form.
+  no scheme, no trailing slash, no trailing dot. The server applies
+  `forge.NormalizeHost` at handler entry as a defence; clients are
+  expected to send the canonical form so their own keying (e.g. token
+  store keys) matches the wire form.
 - 401 and 403 responses from forges must preserve the forge's response
   body in the gRPC status detail (truncated to ~500 chars). Clients use
   this to distinguish bad-token errors from SSO-authorization-required

--- a/internal/forge/host.go
+++ b/internal/forge/host.go
@@ -12,5 +12,6 @@ func NormalizeHost(s string) string {
 	s = strings.TrimPrefix(s, "https://")
 	s = strings.TrimPrefix(s, "http://")
 	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".")
 	return strings.ToLower(s)
 }

--- a/internal/forge/host_test.go
+++ b/internal/forge/host_test.go
@@ -21,6 +21,9 @@ func TestNormalizeHost(t *testing.T) {
 		{"GHE-style subdomain", "github.mycompany.com", "github.mycompany.com"},
 		{"GHE with scheme and case", "https://GitHub.MyCompany.Com", "github.mycompany.com"},
 		{"non-standard port", "gitea.internal:3000", "gitea.internal:3000"},
+		{"trailing dot", "github.com.", "github.com"},
+		{"scheme and trailing dot", "https://github.com.", "github.com"},
+		{"trailing dot and slash", "github.com./", "github.com"},
 		{"empty", "", ""},
 	}
 


### PR DESCRIPTION
Closes #57.

## Summary

Adds `strings.TrimSuffix(s, ".")` to `forge.NormalizeHost` so FQDN-style host input (`github.com.`) normalises to `github.com`, matching the plugin's `HostNormalizer.normalize`. Without this, the plugin keys credentials by `github.com` while the server routes the request by `github.com.` and fails the forge registry lookup.

## Changes

- `internal/forge/host.go` — trim trailing dot before lowercasing.
- `internal/forge/host_test.go` — three new table cases: `github.com.`, `https://github.com.`, `github.com./`. The last pins the trim order (`/` first, then `.`) against future refactors.
- `codewalker-briefing.md` — host normalisation rule now lists "no trailing dot".

## Test plan

- [x] `make ci` passes locally
- [x] All three new cases pass alongside the existing table

https://claude.ai/code/session_01Qbh3mFtBtdPNv5fyKYHRD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbh3mFtBtdPNv5fyKYHRD9)_