### PR TITLE
feat: add ListPullRequests RPC

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -405,6 +405,9 @@ Read from environment variables. No config files in v1.
   this to distinguish bad-token errors from SSO-authorization-required
   errors, and to surface forge-specific guidance (e.g. "Bad credentials"
   vs "token expired") without a second round trip.
+- ForgeHandler implementations must support listing open pull requests via
+  `ListPullRequests(ctx, owner, repo, token)` so clients can build PR
+  pickers without hardcoding forge-specific API calls.
 - When in doubt about a design decision, check this document before asking. If it is not covered here, ask the user
 
 ### Tooling

--- a/gen/codewalker/v1/codewalker.pb.go
+++ b/gen/codewalker/v1/codewalker.pb.go
@@ -2973,6 +2973,192 @@ func (x *FileOrderer) GetDescription() string {
 	return ""
 }
 
+type ListPullRequestsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Forge host (e.g. "github.com"). Must be the canonical form per
+	// forge.NormalizeHost — clients are expected to normalise before sending.
+	Host string `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	// Repository owner (org or user).
+	Owner string `protobuf:"bytes,2,opt,name=owner,proto3" json:"owner,omitempty"`
+	// Repository name.
+	Repo string `protobuf:"bytes,3,opt,name=repo,proto3" json:"repo,omitempty"`
+	// Optional forge token. Empty means unauthenticated (public repo).
+	// The server uses this verbatim — there is no server-side resolution.
+	ForgeToken    string `protobuf:"bytes,4,opt,name=forge_token,json=forgeToken,proto3" json:"forge_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPullRequestsRequest) Reset() {
+	*x = ListPullRequestsRequest{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPullRequestsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPullRequestsRequest) ProtoMessage() {}
+
+func (x *ListPullRequestsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPullRequestsRequest.ProtoReflect.Descriptor instead.
+func (*ListPullRequestsRequest) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ListPullRequestsRequest) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *ListPullRequestsRequest) GetOwner() string {
+	if x != nil {
+		return x.Owner
+	}
+	return ""
+}
+
+func (x *ListPullRequestsRequest) GetRepo() string {
+	if x != nil {
+		return x.Repo
+	}
+	return ""
+}
+
+func (x *ListPullRequestsRequest) GetForgeToken() string {
+	if x != nil {
+		return x.ForgeToken
+	}
+	return ""
+}
+
+type ListPullRequestsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PullRequests  []*PullRequestSummary  `protobuf:"bytes,1,rep,name=pull_requests,json=pullRequests,proto3" json:"pull_requests,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPullRequestsResponse) Reset() {
+	*x = ListPullRequestsResponse{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPullRequestsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPullRequestsResponse) ProtoMessage() {}
+
+func (x *ListPullRequestsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPullRequestsResponse.ProtoReflect.Descriptor instead.
+func (*ListPullRequestsResponse) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ListPullRequestsResponse) GetPullRequests() []*PullRequestSummary {
+	if x != nil {
+		return x.PullRequests
+	}
+	return nil
+}
+
+type PullRequestSummary struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Number        int32                  `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
+	Title         string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	Author        string                 `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
+	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PullRequestSummary) Reset() {
+	*x = PullRequestSummary{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PullRequestSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PullRequestSummary) ProtoMessage() {}
+
+func (x *PullRequestSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PullRequestSummary.ProtoReflect.Descriptor instead.
+func (*PullRequestSummary) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *PullRequestSummary) GetNumber() int32 {
+	if x != nil {
+		return x.Number
+	}
+	return 0
+}
+
+func (x *PullRequestSummary) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *PullRequestSummary) GetAuthor() string {
+	if x != nil {
+		return x.Author
+	}
+	return ""
+}
+
+func (x *PullRequestSummary) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
 var File_codewalker_v1_codewalker_proto protoreflect.FileDescriptor
 
 const file_codewalker_v1_codewalker_proto_rawDesc = "" +
@@ -3172,7 +3358,20 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\borderers\x18\x01 \x03(\v2\x1a.codewalker.v1.FileOrdererR\borderers\"C\n" +
 	"\vFileOrderer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescription*b\n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\"x\n" +
+	"\x17ListPullRequestsRequest\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
+	"\x05owner\x18\x02 \x01(\tR\x05owner\x12\x12\n" +
+	"\x04repo\x18\x03 \x01(\tR\x04repo\x12\x1f\n" +
+	"\vforge_token\x18\x04 \x01(\tR\n" +
+	"forgeToken\"b\n" +
+	"\x18ListPullRequestsResponse\x12F\n" +
+	"\rpull_requests\x18\x01 \x03(\v2!.codewalker.v1.PullRequestSummaryR\fpullRequests\"l\n" +
+	"\x12PullRequestSummary\x12\x16\n" +
+	"\x06number\x18\x01 \x01(\x05R\x06number\x12\x14\n" +
+	"\x05title\x18\x02 \x01(\tR\x05title\x12\x16\n" +
+	"\x06author\x18\x03 \x01(\tR\x06author\x12\x10\n" +
+	"\x03url\x18\x04 \x01(\tR\x03url*b\n" +
 	"\vSessionKind\x12\x1c\n" +
 	"\x18SESSION_KIND_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SESSION_KIND_WALKTHROUGH\x10\x01\x12\x17\n" +
@@ -3243,7 +3442,7 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\x1cERROR_CODE_FORGE_AUTH_FAILED\x10\b\x12\x1e\n" +
 	"\x1aERROR_CODE_FORGE_NOT_FOUND\x10\t\x12\x1a\n" +
 	"\x16ERROR_CODE_INVALID_URL\x10\n" +
-	"2\x89\x06\n" +
+	"2\xee\x06\n" +
 	"\n" +
 	"CodeWalker\x12Q\n" +
 	"\n" +
@@ -3256,7 +3455,8 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\fCloseSession\x12\".codewalker.v1.CloseSessionRequest\x1a#.codewalker.v1.CloseSessionResponse\x12W\n" +
 	"\fListSessions\x12\".codewalker.v1.ListSessionsRequest\x1a#.codewalker.v1.ListSessionsResponse\x12[\n" +
 	"\x11OpenReviewSession\x12'.codewalker.v1.OpenReviewSessionRequest\x1a\x1b.codewalker.v1.SessionEvent0\x01\x12c\n" +
-	"\x10ListFileOrderers\x12&.codewalker.v1.ListFileOrderersRequest\x1a'.codewalker.v1.ListFileOrderersResponseB1Z/github.com/yourorg/codewalker/gen/codewalker/v1b\x06proto3"
+	"\x10ListFileOrderers\x12&.codewalker.v1.ListFileOrderersRequest\x1a'.codewalker.v1.ListFileOrderersResponse\x12c\n" +
+	"\x10ListPullRequests\x12&.codewalker.v1.ListPullRequestsRequest\x1a'.codewalker.v1.ListPullRequestsResponseB1Z/github.com/yourorg/codewalker/gen/codewalker/v1b\x06proto3"
 
 var (
 	file_codewalker_v1_codewalker_proto_rawDescOnce sync.Once
@@ -3271,7 +3471,7 @@ func file_codewalker_v1_codewalker_proto_rawDescGZIP() []byte {
 }
 
 var file_codewalker_v1_codewalker_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(SessionKind)(0),                 // 0: codewalker.v1.SessionKind
 	(StepKind)(0),                    // 1: codewalker.v1.StepKind
@@ -3315,6 +3515,9 @@ var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(*ListFileOrderersRequest)(nil),  // 39: codewalker.v1.ListFileOrderersRequest
 	(*ListFileOrderersResponse)(nil), // 40: codewalker.v1.ListFileOrderersResponse
 	(*FileOrderer)(nil),              // 41: codewalker.v1.FileOrderer
+	(*ListPullRequestsRequest)(nil),  // 42: codewalker.v1.ListPullRequestsRequest
+	(*ListPullRequestsResponse)(nil), // 43: codewalker.v1.ListPullRequestsResponse
+	(*PullRequestSummary)(nil),       // 44: codewalker.v1.PullRequestSummary
 }
 var file_codewalker_v1_codewalker_proto_depIdxs = []int32{
 	8,  // 0: codewalker.v1.OpenSessionRequest.experience_level:type_name -> codewalker.v1.ExperienceLevel
@@ -3351,29 +3554,32 @@ var file_codewalker_v1_codewalker_proto_depIdxs = []int32{
 	7,  // 31: codewalker.v1.ReviewFile.change:type_name -> codewalker.v1.ChangeKind
 	9,  // 32: codewalker.v1.ServiceError.code:type_name -> codewalker.v1.ErrorCode
 	41, // 33: codewalker.v1.ListFileOrderersResponse.orderers:type_name -> codewalker.v1.FileOrderer
-	37, // 34: codewalker.v1.CodeWalker.GetVersion:input_type -> codewalker.v1.GetVersionRequest
-	10, // 35: codewalker.v1.CodeWalker.OpenSession:input_type -> codewalker.v1.OpenSessionRequest
-	23, // 36: codewalker.v1.CodeWalker.Navigate:input_type -> codewalker.v1.NavigateRequest
-	28, // 37: codewalker.v1.CodeWalker.Rephrase:input_type -> codewalker.v1.RephraseRequest
-	30, // 38: codewalker.v1.CodeWalker.ExpandTerm:input_type -> codewalker.v1.ExpandTermRequest
-	14, // 39: codewalker.v1.CodeWalker.CloseSession:input_type -> codewalker.v1.CloseSessionRequest
-	16, // 40: codewalker.v1.CodeWalker.ListSessions:input_type -> codewalker.v1.ListSessionsRequest
-	31, // 41: codewalker.v1.CodeWalker.OpenReviewSession:input_type -> codewalker.v1.OpenReviewSessionRequest
-	39, // 42: codewalker.v1.CodeWalker.ListFileOrderers:input_type -> codewalker.v1.ListFileOrderersRequest
-	38, // 43: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
-	11, // 44: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
-	24, // 45: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
-	24, // 46: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
-	24, // 47: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
-	15, // 48: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
-	17, // 49: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
-	11, // 50: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
-	40, // 51: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
-	43, // [43:52] is the sub-list for method output_type
-	34, // [34:43] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	44, // 34: codewalker.v1.ListPullRequestsResponse.pull_requests:type_name -> codewalker.v1.PullRequestSummary
+	37, // 35: codewalker.v1.CodeWalker.GetVersion:input_type -> codewalker.v1.GetVersionRequest
+	10, // 36: codewalker.v1.CodeWalker.OpenSession:input_type -> codewalker.v1.OpenSessionRequest
+	23, // 37: codewalker.v1.CodeWalker.Navigate:input_type -> codewalker.v1.NavigateRequest
+	28, // 38: codewalker.v1.CodeWalker.Rephrase:input_type -> codewalker.v1.RephraseRequest
+	30, // 39: codewalker.v1.CodeWalker.ExpandTerm:input_type -> codewalker.v1.ExpandTermRequest
+	14, // 40: codewalker.v1.CodeWalker.CloseSession:input_type -> codewalker.v1.CloseSessionRequest
+	16, // 41: codewalker.v1.CodeWalker.ListSessions:input_type -> codewalker.v1.ListSessionsRequest
+	31, // 42: codewalker.v1.CodeWalker.OpenReviewSession:input_type -> codewalker.v1.OpenReviewSessionRequest
+	39, // 43: codewalker.v1.CodeWalker.ListFileOrderers:input_type -> codewalker.v1.ListFileOrderersRequest
+	42, // 44: codewalker.v1.CodeWalker.ListPullRequests:input_type -> codewalker.v1.ListPullRequestsRequest
+	38, // 45: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
+	11, // 46: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
+	24, // 47: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
+	24, // 48: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
+	24, // 49: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
+	15, // 50: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
+	17, // 51: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
+	11, // 52: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
+	40, // 53: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
+	43, // 54: codewalker.v1.CodeWalker.ListPullRequests:output_type -> codewalker.v1.ListPullRequestsResponse
+	45, // [45:55] is the sub-list for method output_type
+	35, // [35:45] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_codewalker_v1_codewalker_proto_init() }
@@ -3403,7 +3609,7 @@ func file_codewalker_v1_codewalker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_codewalker_v1_codewalker_proto_rawDesc), len(file_codewalker_v1_codewalker_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   32,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/codewalker/v1/codewalker_grpc.pb.go
+++ b/gen/codewalker/v1/codewalker_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	CodeWalker_ListSessions_FullMethodName      = "/codewalker.v1.CodeWalker/ListSessions"
 	CodeWalker_OpenReviewSession_FullMethodName = "/codewalker.v1.CodeWalker/OpenReviewSession"
 	CodeWalker_ListFileOrderers_FullMethodName  = "/codewalker.v1.CodeWalker/ListFileOrderers"
+	CodeWalker_ListPullRequests_FullMethodName  = "/codewalker.v1.CodeWalker/ListPullRequests"
 )
 
 // CodeWalkerClient is the client API for CodeWalker service.
@@ -60,6 +61,9 @@ type CodeWalkerClient interface {
 	// List available file ordering strategies. Clients can use this to
 	// populate user-facing pickers without hardcoding the strategy names.
 	ListFileOrderers(ctx context.Context, in *ListFileOrderersRequest, opts ...grpc.CallOption) (*ListFileOrderersResponse, error)
+	// List open pull requests for a repository.
+	// Used by clients to populate a PR picker.
+	ListPullRequests(ctx context.Context, in *ListPullRequestsRequest, opts ...grpc.CallOption) (*ListPullRequestsResponse, error)
 }
 
 type codeWalkerClient struct {
@@ -205,6 +209,16 @@ func (c *codeWalkerClient) ListFileOrderers(ctx context.Context, in *ListFileOrd
 	return out, nil
 }
 
+func (c *codeWalkerClient) ListPullRequests(ctx context.Context, in *ListPullRequestsRequest, opts ...grpc.CallOption) (*ListPullRequestsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListPullRequestsResponse)
+	err := c.cc.Invoke(ctx, CodeWalker_ListPullRequests_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CodeWalkerServer is the server API for CodeWalker service.
 // All implementations should embed UnimplementedCodeWalkerServer
 // for forward compatibility.
@@ -235,6 +249,9 @@ type CodeWalkerServer interface {
 	// List available file ordering strategies. Clients can use this to
 	// populate user-facing pickers without hardcoding the strategy names.
 	ListFileOrderers(context.Context, *ListFileOrderersRequest) (*ListFileOrderersResponse, error)
+	// List open pull requests for a repository.
+	// Used by clients to populate a PR picker.
+	ListPullRequests(context.Context, *ListPullRequestsRequest) (*ListPullRequestsResponse, error)
 }
 
 // UnimplementedCodeWalkerServer should be embedded to have
@@ -270,6 +287,9 @@ func (UnimplementedCodeWalkerServer) OpenReviewSession(*OpenReviewSessionRequest
 }
 func (UnimplementedCodeWalkerServer) ListFileOrderers(context.Context, *ListFileOrderersRequest) (*ListFileOrderersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListFileOrderers not implemented")
+}
+func (UnimplementedCodeWalkerServer) ListPullRequests(context.Context, *ListPullRequestsRequest) (*ListPullRequestsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListPullRequests not implemented")
 }
 func (UnimplementedCodeWalkerServer) testEmbeddedByValue() {}
 
@@ -418,6 +438,24 @@ func _CodeWalker_ListFileOrderers_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CodeWalker_ListPullRequests_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListPullRequestsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CodeWalkerServer).ListPullRequests(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CodeWalker_ListPullRequests_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CodeWalkerServer).ListPullRequests(ctx, req.(*ListPullRequestsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CodeWalker_ServiceDesc is the grpc.ServiceDesc for CodeWalker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -440,6 +478,10 @@ var CodeWalker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListFileOrderers",
 			Handler:    _CodeWalker_ListFileOrderers_Handler,
+		},
+		{
+			MethodName: "ListPullRequests",
+			Handler:    _CodeWalker_ListPullRequests_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/internal/forge/forges/github.go
+++ b/internal/forge/forges/github.go
@@ -18,7 +18,28 @@ func init() {
 	forge.Register(&githubHandler{})
 }
 
-type githubHandler struct{}
+type githubHandler struct {
+	// apiBaseURL overrides https://api.github.com in tests.
+	// The empty string means use the default.
+	apiBaseURL string
+	// httpClient overrides http.DefaultClient in tests.
+	// The nil value means use the default.
+	httpClient *http.Client
+}
+
+func (g *githubHandler) baseURL() string {
+	if g.apiBaseURL != "" {
+		return g.apiBaseURL
+	}
+	return "https://api.github.com"
+}
+
+func (g *githubHandler) client() *http.Client {
+	if g.httpClient != nil {
+		return g.httpClient
+	}
+	return http.DefaultClient
+}
 
 func (g *githubHandler) Hosts() []string {
 	return []string{"github.com"}
@@ -86,8 +107,8 @@ func (g *githubHandler) FetchReview(ctx context.Context, fc *forge.ForgeContext,
 }
 
 func (g *githubHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext, path, ref, token string) ([]byte, error) {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
-		fc.Owner, fc.Repo, path, url.QueryEscape(ref))
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s",
+		g.baseURL(), fc.Owner, fc.Repo, path, url.QueryEscape(ref))
 	resp, err := g.apiDo(ctx, apiURL, token)
 	if err != nil {
 		return nil, err
@@ -112,6 +133,43 @@ func (g *githubHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext, p
 		return nil, fmt.Errorf("decode base64 content for %q: %w", path, err)
 	}
 	return data, nil
+}
+
+func (g *githubHandler) ListPullRequests(ctx context.Context, owner, repo, token string) ([]*forge.PullRequest, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls?state=open&per_page=100", g.baseURL(), owner, repo)
+	// TODO: paginate — repositories with more than 100 open PRs will be silently truncated.
+	// GitHub returns a Link header with rel="next" for subsequent pages.
+	resp, err := g.apiDo(ctx, apiURL, token)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := checkStatus(resp); err != nil {
+		return nil, err
+	}
+
+	var items []struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		HTMLURL string `json:"html_url"`
+		User    struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, fmt.Errorf("decode pull request list response: %w", err)
+	}
+
+	out := make([]*forge.PullRequest, 0, len(items))
+	for _, it := range items {
+		out = append(out, &forge.PullRequest{
+			Number: it.Number,
+			Title:  it.Title,
+			Author: it.User.Login,
+			URL:    it.HTMLURL,
+		})
+	}
+	return out, nil
 }
 
 // --- GitHub API types ---
@@ -160,7 +218,7 @@ func (g *githubHandler) apiDo(ctx context.Context, apiURL, token string) (*http.
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	return http.DefaultClient.Do(req)
+	return g.client().Do(req)
 }
 
 // errBodyMaxBytes caps how much of a forge response body we propagate into the
@@ -203,7 +261,7 @@ func readBodySnippet(r io.Reader) string {
 }
 
 func (g *githubHandler) fetchPRReview(ctx context.Context, fc *forge.ForgeContext, token string) (*forge.ReviewPayload, error) {
-	prURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", fc.Owner, fc.Repo, fc.PRNumber)
+	prURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", g.baseURL(), fc.Owner, fc.Repo, fc.PRNumber)
 
 	resp, err := g.apiDo(ctx, prURL, token)
 	if err != nil {
@@ -248,7 +306,7 @@ func (g *githubHandler) fetchPRReview(ctx context.Context, fc *forge.ForgeContex
 }
 
 func (g *githubHandler) fetchCommitReview(ctx context.Context, fc *forge.ForgeContext, token string) (*forge.ReviewPayload, error) {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s", fc.Owner, fc.Repo, fc.HeadRef)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s", g.baseURL(), fc.Owner, fc.Repo, fc.HeadRef)
 	resp, err := g.apiDo(ctx, apiURL, token)
 	if err != nil {
 		return nil, err
@@ -275,8 +333,8 @@ func (g *githubHandler) fetchCommitReview(ctx context.Context, fc *forge.ForgeCo
 }
 
 func (g *githubHandler) fetchComparisonReview(ctx context.Context, fc *forge.ForgeContext, token string) (*forge.ReviewPayload, error) {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/compare/%s...%s",
-		fc.Owner, fc.Repo, fc.BaseRef, fc.HeadRef)
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/compare/%s...%s",
+		g.baseURL(), fc.Owner, fc.Repo, fc.BaseRef, fc.HeadRef)
 	resp, err := g.apiDo(ctx, apiURL, token)
 	if err != nil {
 		return nil, err

--- a/internal/forge/forges/github_test.go
+++ b/internal/forge/forges/github_test.go
@@ -1,6 +1,11 @@
 package forges
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/yourorg/codewalker/internal/forge"
@@ -158,6 +163,154 @@ func TestParseHunkRange(t *testing.T) {
 			}
 			if count != tt.wantCount {
 				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestListPullRequests(t *testing.T) {
+	const successBody = `[
+		{"number": 42, "title": "Add foo", "html_url": "https://github.com/octocat/hello-world/pull/42",
+		 "user": {"login": "alice"}},
+		{"number": 43, "title": "Fix bar", "html_url": "https://github.com/octocat/hello-world/pull/43",
+		 "user": {"login": "bob"}}
+	]`
+	const samlBody = `{"message":"Resource protected by organization SAML enforcement","documentation_url":"https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on"}`
+	const badCredsBody = `{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`
+	const notFoundBody = `{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}`
+
+	tests := []struct {
+		name         string
+		token        string
+		status       int
+		body         string
+		wantCount    int
+		wantErrCode  forge.ErrCode
+		wantErr      bool
+		wantDetail   string
+		wantAuthHdr  string
+		checkResults func(t *testing.T, prs []*forge.PullRequest)
+	}{
+		{
+			name:      "success with multiple PRs",
+			token:     "ghp_secret",
+			status:    http.StatusOK,
+			body:      successBody,
+			wantCount: 2,
+			wantAuthHdr: "Bearer ghp_secret",
+			checkResults: func(t *testing.T, prs []*forge.PullRequest) {
+				if prs[0].Number != 42 || prs[0].Title != "Add foo" || prs[0].Author != "alice" ||
+					prs[0].URL != "https://github.com/octocat/hello-world/pull/42" {
+					t.Errorf("PR[0] = %+v", prs[0])
+				}
+				if prs[1].Number != 43 || prs[1].Author != "bob" {
+					t.Errorf("PR[1] = %+v", prs[1])
+				}
+			},
+		},
+		{
+			name:        "empty response",
+			token:       "ghp_secret",
+			status:      http.StatusOK,
+			body:        `[]`,
+			wantCount:   0,
+			wantAuthHdr: "Bearer ghp_secret",
+		},
+		{
+			name:        "401 preserves body in detail",
+			token:       "bad_token",
+			status:      http.StatusUnauthorized,
+			body:        badCredsBody,
+			wantErr:     true,
+			wantErrCode: forge.ErrCodeAuthFailed,
+			wantDetail:  "Bad credentials",
+			wantAuthHdr: "Bearer bad_token",
+		},
+		{
+			name:        "403 SAML SSO preserves body in detail",
+			token:       "ghp_secret",
+			status:      http.StatusForbidden,
+			body:        samlBody,
+			wantErr:     true,
+			wantErrCode: forge.ErrCodeAuthFailed,
+			wantDetail:  "SAML enforcement",
+			wantAuthHdr: "Bearer ghp_secret",
+		},
+		{
+			name:        "404 maps to ErrCodeNotFound",
+			token:       "",
+			status:      http.StatusNotFound,
+			body:        notFoundBody,
+			wantErr:     true,
+			wantErrCode: forge.ErrCodeNotFound,
+			wantAuthHdr: "",
+		},
+		{
+			name:        "empty token sends no Authorization header",
+			token:       "",
+			status:      http.StatusOK,
+			body:        `[]`,
+			wantAuthHdr: "",
+		},
+		{
+			name:        "non-empty token sends Bearer Authorization header",
+			token:       "ghp_xyz",
+			status:      http.StatusOK,
+			body:        `[]`,
+			wantAuthHdr: "Bearer ghp_xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAuth string
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				gotPath = r.URL.RequestURI()
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			h := &githubHandler{apiBaseURL: srv.URL, httpClient: srv.Client()}
+			prs, err := h.ListPullRequests(context.Background(), "octocat", "hello-world", tt.token)
+
+			if gotAuth != tt.wantAuthHdr {
+				t.Errorf("Authorization header = %q, want %q", gotAuth, tt.wantAuthHdr)
+			}
+			if !strings.HasPrefix(gotPath, "/repos/octocat/hello-world/pulls") {
+				t.Errorf("path = %q, want /repos/octocat/hello-world/pulls...", gotPath)
+			}
+			if !strings.Contains(gotPath, "state=open") {
+				t.Errorf("path = %q, want state=open in query", gotPath)
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("got nil error, want error")
+				}
+				var fe *forge.Error
+				if !errors.As(err, &fe) {
+					t.Fatalf("error is not *forge.Error: %T %v", err, err)
+				}
+				if fe.Code != tt.wantErrCode {
+					t.Errorf("Code = %v, want %v", fe.Code, tt.wantErrCode)
+				}
+				if tt.wantDetail != "" && !strings.Contains(fe.Detail, tt.wantDetail) {
+					t.Errorf("Detail = %q, want substring %q", fe.Detail, tt.wantDetail)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(prs) != tt.wantCount {
+				t.Fatalf("got %d PRs, want %d", len(prs), tt.wantCount)
+			}
+			if tt.checkResults != nil {
+				tt.checkResults(t, prs)
 			}
 		})
 	}

--- a/internal/forge/handler.go
+++ b/internal/forge/handler.go
@@ -22,4 +22,16 @@ type ForgeHandler interface {
 	// FetchFile fetches raw file content at a specific ref.
 	// Used to populate context_before and context_after on HunkSpan.
 	FetchFile(ctx context.Context, fc *ForgeContext, path, ref, token string) ([]byte, error)
+
+	// ListPullRequests returns open pull requests for a repository.
+	// token may be empty for public repositories.
+	ListPullRequests(ctx context.Context, owner, repo, token string) ([]*PullRequest, error)
+}
+
+// PullRequest is a forge-agnostic summary of an open pull request.
+type PullRequest struct {
+	Number int
+	Title  string
+	Author string
+	URL    string
 }

--- a/proto/codewalker/v1/codewalker.proto
+++ b/proto/codewalker/v1/codewalker.proto
@@ -43,6 +43,10 @@ service CodeWalker {
   // List available file ordering strategies. Clients can use this to
   // populate user-facing pickers without hardcoding the strategy names.
   rpc ListFileOrderers(ListFileOrderersRequest) returns (ListFileOrderersResponse);
+
+  // List open pull requests for a repository.
+  // Used by clients to populate a PR picker.
+  rpc ListPullRequests(ListPullRequestsRequest) returns (ListPullRequestsResponse);
 }
 
 // ─────────────────────────────────────────────
@@ -504,4 +508,31 @@ message ListFileOrderersResponse {
 message FileOrderer {
   string name        = 1;
   string description = 2;
+}
+
+message ListPullRequestsRequest {
+  // Forge host (e.g. "github.com"). Must be the canonical form per
+  // forge.NormalizeHost — clients are expected to normalise before sending.
+  string host = 1;
+
+  // Repository owner (org or user).
+  string owner = 2;
+
+  // Repository name.
+  string repo = 3;
+
+  // Optional forge token. Empty means unauthenticated (public repo).
+  // The server uses this verbatim — there is no server-side resolution.
+  string forge_token = 4;
+}
+
+message ListPullRequestsResponse {
+  repeated PullRequestSummary pull_requests = 1;
+}
+
+message PullRequestSummary {
+  int32  number = 1;
+  string title  = 2;
+  string author = 3;
+  string url    = 4;
 }

--- a/server/list_pull_requests.go
+++ b/server/list_pull_requests.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"context"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	_ "github.com/yourorg/codewalker/internal/forge/forges"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ListPullRequests implements CodeWalkerServer.ListPullRequests.
+func (s *Server) ListPullRequests(ctx context.Context, req *v1.ListPullRequestsRequest) (*v1.ListPullRequestsResponse, error) {
+	host := forge.NormalizeHost(req.Host)
+	if host == "" || req.Owner == "" || req.Repo == "" {
+		return nil, status.Error(codes.InvalidArgument, "host, owner, and repo are required")
+	}
+
+	handler, err := forge.Resolve(host)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unsupported forge host %q: %v", host, err)
+	}
+
+	prs, err := handler.ListPullRequests(ctx, req.Owner, req.Repo, req.ForgeToken)
+	if err != nil {
+		return nil, forgeErrToStatus(err, "list pull requests")
+	}
+
+	out := make([]*v1.PullRequestSummary, 0, len(prs))
+	for _, p := range prs {
+		out = append(out, &v1.PullRequestSummary{
+			Number: int32(p.Number),
+			Title:  p.Title,
+			Author: p.Author,
+			Url:    p.URL,
+		})
+	}
+	return &v1.ListPullRequestsResponse{PullRequests: out}, nil
+}

--- a/server/open_review_session_ordering_test.go
+++ b/server/open_review_session_ordering_test.go
@@ -51,6 +51,10 @@ func (m *multiFileForgeHandler) FetchFile(_ context.Context, _ *forge.ForgeConte
 	return []byte("line\n"), nil
 }
 
+func (m *multiFileForgeHandler) ListPullRequests(_ context.Context, _, _, _ string) ([]*forge.PullRequest, error) {
+	return nil, nil
+}
+
 func init() {
 	forge.Register(&multiFileForgeHandler{})
 }

--- a/server/open_review_session_test.go
+++ b/server/open_review_session_test.go
@@ -65,6 +65,10 @@ func (m *mockForgeHandler) FetchFile(ctx context.Context, fc *forge.ForgeContext
 	return []byte("line 1\nline 2\nline 3\nline 4\nline 5\n"), nil
 }
 
+func (m *mockForgeHandler) ListPullRequests(_ context.Context, _, _, _ string) ([]*forge.PullRequest, error) {
+	return nil, nil
+}
+
 func init() {
 	forge.Register(&mockForgeHandler{})
 }


### PR DESCRIPTION
Closes #43.

## Summary

Adds a `ListPullRequests` RPC that returns the open pull requests for a given
repository via the existing `ForgeHandler` plumbing. Plugins use this to
populate an idle screen with a clickable list of PRs for the current project.

## Proto

- New RPC `CodeWalker.ListPullRequests(ListPullRequestsRequest) returns (ListPullRequestsResponse)`
- New messages `ListPullRequestsRequest`, `ListPullRequestsResponse`, `PullRequestSummary`
- Non-breaking — `ProtoMajor` is unchanged; this is a minor version bump
- Stubs regenerated via `make proto`

## Forge layer

- `forge.ForgeHandler` gains `ListPullRequests(ctx, owner, repo, token) ([]*PullRequest, error)`
- New forge-agnostic `forge.PullRequest` value type (`Number`, `Title`, `Author`, `URL`)
- GitHub implementation hits `GET /repos/{owner}/{repo}/pulls?state=open&per_page=100`
  through the existing `apiDo` + `checkStatus` helpers so 401/403/404 responses
  surface through the existing `forge.Error` mapping with the response body
  preserved on auth failures
- TODO comment added for pagination, mirroring the existing PR-files endpoint
- `githubHandler` gains private `apiBaseURL` and `httpClient` test seams; the
  `init()`-registered handler still uses `https://api.github.com` and
  `http.DefaultClient` by default
- The two existing in-test `ForgeHandler` mocks gain a no-op
  `ListPullRequests` to satisfy the interface

## Server

- New `server/list_pull_requests.go` handler:
  - Applies `forge.NormalizeHost` to `req.Host` at entry
  - Returns `InvalidArgument` if `host`/`owner`/`repo` are missing or the host
    is unsupported
  - Treats `req.ForgeToken` as opaque caller-supplied state (empty allowed),
    consistent with the contract from PR #55
  - Maps forge errors via the shared `forgeErrToStatus` helper

## Tests

Table-driven tests for `githubHandler.ListPullRequests` covering all seven
cases from the issue — success with multiple PRs, empty response, 401, 403
with SAML SSO body, 404, empty token (no `Authorization` header), and
non-empty token (`Bearer ` header). The auth-header assertions pin the
contract end-to-end.

## Docs

- `codewalker-briefing.md`: appended a new bullet under Development rules →
  Code stating that `ForgeHandler` implementations must support
  `ListPullRequests`
- `README.md` not updated — no install/run/use change for end users

## Test plan

- [x] `make ci` passes locally (buf lint, go vet, go build, go test)
- [x] New table-driven GitHub tests pass
- [x] Existing forge / server / orderer tests still pass


---
_Generated by [Claude Code](https://claude.ai/code/session_017GxguTFxYNQW26EwNefoDa)_