### PR TITLE
feat: add FetchFileAtRef RPC

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -408,6 +408,10 @@ Read from environment variables. No config files in v1.
 - ForgeHandler implementations must support listing open pull requests via
   `ListPullRequests(ctx, owner, repo, token)` so clients can build PR
   pickers without hardcoding forge-specific API calls.
+- ForgeHandler implementations support fetching arbitrary file content at
+  a ref via FetchFile. The FetchFileAtRef RPC exposes this directly to
+  clients so review session views can render the PR's head-ref version
+  of a file rather than the working-tree copy.
 - When in doubt about a design decision, check this document before asking. If it is not covered here, ask the user
 
 ### Tooling

--- a/gen/codewalker/v1/codewalker.pb.go
+++ b/gen/codewalker/v1/codewalker.pb.go
@@ -3159,6 +3159,141 @@ func (x *PullRequestSummary) GetUrl() string {
 	return ""
 }
 
+type FetchFileAtRefRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Forge host. Canonical form per forge.NormalizeHost.
+	Host string `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	// Repository owner.
+	Owner string `protobuf:"bytes,2,opt,name=owner,proto3" json:"owner,omitempty"`
+	// Repository name.
+	Repo string `protobuf:"bytes,3,opt,name=repo,proto3" json:"repo,omitempty"`
+	// File path relative to the repo root.
+	Path string `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`
+	// Git ref (commit SHA, branch, or tag).
+	Ref string `protobuf:"bytes,5,opt,name=ref,proto3" json:"ref,omitempty"`
+	// Optional forge token. Empty means unauthenticated.
+	ForgeToken    string `protobuf:"bytes,6,opt,name=forge_token,json=forgeToken,proto3" json:"forge_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FetchFileAtRefRequest) Reset() {
+	*x = FetchFileAtRefRequest{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FetchFileAtRefRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FetchFileAtRefRequest) ProtoMessage() {}
+
+func (x *FetchFileAtRefRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FetchFileAtRefRequest.ProtoReflect.Descriptor instead.
+func (*FetchFileAtRefRequest) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *FetchFileAtRefRequest) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *FetchFileAtRefRequest) GetOwner() string {
+	if x != nil {
+		return x.Owner
+	}
+	return ""
+}
+
+func (x *FetchFileAtRefRequest) GetRepo() string {
+	if x != nil {
+		return x.Repo
+	}
+	return ""
+}
+
+func (x *FetchFileAtRefRequest) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *FetchFileAtRefRequest) GetRef() string {
+	if x != nil {
+		return x.Ref
+	}
+	return ""
+}
+
+func (x *FetchFileAtRefRequest) GetForgeToken() string {
+	if x != nil {
+		return x.ForgeToken
+	}
+	return ""
+}
+
+type FetchFileAtRefResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Raw file content as returned by the forge.
+	Content       []byte `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FetchFileAtRefResponse) Reset() {
+	*x = FetchFileAtRefResponse{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FetchFileAtRefResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FetchFileAtRefResponse) ProtoMessage() {}
+
+func (x *FetchFileAtRefResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FetchFileAtRefResponse.ProtoReflect.Descriptor instead.
+func (*FetchFileAtRefResponse) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *FetchFileAtRefResponse) GetContent() []byte {
+	if x != nil {
+		return x.Content
+	}
+	return nil
+}
+
 var File_codewalker_v1_codewalker_proto protoreflect.FileDescriptor
 
 const file_codewalker_v1_codewalker_proto_rawDesc = "" +
@@ -3371,7 +3506,17 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\x06number\x18\x01 \x01(\x05R\x06number\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x16\n" +
 	"\x06author\x18\x03 \x01(\tR\x06author\x12\x10\n" +
-	"\x03url\x18\x04 \x01(\tR\x03url*b\n" +
+	"\x03url\x18\x04 \x01(\tR\x03url\"\x9c\x01\n" +
+	"\x15FetchFileAtRefRequest\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
+	"\x05owner\x18\x02 \x01(\tR\x05owner\x12\x12\n" +
+	"\x04repo\x18\x03 \x01(\tR\x04repo\x12\x12\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\x12\x10\n" +
+	"\x03ref\x18\x05 \x01(\tR\x03ref\x12\x1f\n" +
+	"\vforge_token\x18\x06 \x01(\tR\n" +
+	"forgeToken\"2\n" +
+	"\x16FetchFileAtRefResponse\x12\x18\n" +
+	"\acontent\x18\x01 \x01(\fR\acontent*b\n" +
 	"\vSessionKind\x12\x1c\n" +
 	"\x18SESSION_KIND_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SESSION_KIND_WALKTHROUGH\x10\x01\x12\x17\n" +
@@ -3442,7 +3587,7 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\x1cERROR_CODE_FORGE_AUTH_FAILED\x10\b\x12\x1e\n" +
 	"\x1aERROR_CODE_FORGE_NOT_FOUND\x10\t\x12\x1a\n" +
 	"\x16ERROR_CODE_INVALID_URL\x10\n" +
-	"2\xee\x06\n" +
+	"2\xcd\a\n" +
 	"\n" +
 	"CodeWalker\x12Q\n" +
 	"\n" +
@@ -3456,7 +3601,8 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\fListSessions\x12\".codewalker.v1.ListSessionsRequest\x1a#.codewalker.v1.ListSessionsResponse\x12[\n" +
 	"\x11OpenReviewSession\x12'.codewalker.v1.OpenReviewSessionRequest\x1a\x1b.codewalker.v1.SessionEvent0\x01\x12c\n" +
 	"\x10ListFileOrderers\x12&.codewalker.v1.ListFileOrderersRequest\x1a'.codewalker.v1.ListFileOrderersResponse\x12c\n" +
-	"\x10ListPullRequests\x12&.codewalker.v1.ListPullRequestsRequest\x1a'.codewalker.v1.ListPullRequestsResponseB1Z/github.com/yourorg/codewalker/gen/codewalker/v1b\x06proto3"
+	"\x10ListPullRequests\x12&.codewalker.v1.ListPullRequestsRequest\x1a'.codewalker.v1.ListPullRequestsResponse\x12]\n" +
+	"\x0eFetchFileAtRef\x12$.codewalker.v1.FetchFileAtRefRequest\x1a%.codewalker.v1.FetchFileAtRefResponseB1Z/github.com/yourorg/codewalker/gen/codewalker/v1b\x06proto3"
 
 var (
 	file_codewalker_v1_codewalker_proto_rawDescOnce sync.Once
@@ -3471,7 +3617,7 @@ func file_codewalker_v1_codewalker_proto_rawDescGZIP() []byte {
 }
 
 var file_codewalker_v1_codewalker_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(SessionKind)(0),                 // 0: codewalker.v1.SessionKind
 	(StepKind)(0),                    // 1: codewalker.v1.StepKind
@@ -3518,6 +3664,8 @@ var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(*ListPullRequestsRequest)(nil),  // 42: codewalker.v1.ListPullRequestsRequest
 	(*ListPullRequestsResponse)(nil), // 43: codewalker.v1.ListPullRequestsResponse
 	(*PullRequestSummary)(nil),       // 44: codewalker.v1.PullRequestSummary
+	(*FetchFileAtRefRequest)(nil),    // 45: codewalker.v1.FetchFileAtRefRequest
+	(*FetchFileAtRefResponse)(nil),   // 46: codewalker.v1.FetchFileAtRefResponse
 }
 var file_codewalker_v1_codewalker_proto_depIdxs = []int32{
 	8,  // 0: codewalker.v1.OpenSessionRequest.experience_level:type_name -> codewalker.v1.ExperienceLevel
@@ -3565,18 +3713,20 @@ var file_codewalker_v1_codewalker_proto_depIdxs = []int32{
 	31, // 42: codewalker.v1.CodeWalker.OpenReviewSession:input_type -> codewalker.v1.OpenReviewSessionRequest
 	39, // 43: codewalker.v1.CodeWalker.ListFileOrderers:input_type -> codewalker.v1.ListFileOrderersRequest
 	42, // 44: codewalker.v1.CodeWalker.ListPullRequests:input_type -> codewalker.v1.ListPullRequestsRequest
-	38, // 45: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
-	11, // 46: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
-	24, // 47: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
-	24, // 48: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
-	24, // 49: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
-	15, // 50: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
-	17, // 51: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
-	11, // 52: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
-	40, // 53: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
-	43, // 54: codewalker.v1.CodeWalker.ListPullRequests:output_type -> codewalker.v1.ListPullRequestsResponse
-	45, // [45:55] is the sub-list for method output_type
-	35, // [35:45] is the sub-list for method input_type
+	45, // 45: codewalker.v1.CodeWalker.FetchFileAtRef:input_type -> codewalker.v1.FetchFileAtRefRequest
+	38, // 46: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
+	11, // 47: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
+	24, // 48: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
+	24, // 49: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
+	24, // 50: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
+	15, // 51: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
+	17, // 52: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
+	11, // 53: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
+	40, // 54: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
+	43, // 55: codewalker.v1.CodeWalker.ListPullRequests:output_type -> codewalker.v1.ListPullRequestsResponse
+	46, // 56: codewalker.v1.CodeWalker.FetchFileAtRef:output_type -> codewalker.v1.FetchFileAtRefResponse
+	46, // [46:57] is the sub-list for method output_type
+	35, // [35:46] is the sub-list for method input_type
 	35, // [35:35] is the sub-list for extension type_name
 	35, // [35:35] is the sub-list for extension extendee
 	0,  // [0:35] is the sub-list for field type_name
@@ -3609,7 +3759,7 @@ func file_codewalker_v1_codewalker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_codewalker_v1_codewalker_proto_rawDesc), len(file_codewalker_v1_codewalker_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/codewalker/v1/codewalker_grpc.pb.go
+++ b/gen/codewalker/v1/codewalker_grpc.pb.go
@@ -29,6 +29,7 @@ const (
 	CodeWalker_OpenReviewSession_FullMethodName = "/codewalker.v1.CodeWalker/OpenReviewSession"
 	CodeWalker_ListFileOrderers_FullMethodName  = "/codewalker.v1.CodeWalker/ListFileOrderers"
 	CodeWalker_ListPullRequests_FullMethodName  = "/codewalker.v1.CodeWalker/ListPullRequests"
+	CodeWalker_FetchFileAtRef_FullMethodName    = "/codewalker.v1.CodeWalker/FetchFileAtRef"
 )
 
 // CodeWalkerClient is the client API for CodeWalker service.
@@ -64,6 +65,10 @@ type CodeWalkerClient interface {
 	// List open pull requests for a repository.
 	// Used by clients to populate a PR picker.
 	ListPullRequests(ctx context.Context, in *ListPullRequestsRequest, opts ...grpc.CallOption) (*ListPullRequestsResponse, error)
+	// Fetch a file's content at a specific ref via the appropriate forge.
+	// Used by clients to display the head-ref version of a file during a
+	// review session, where the working-tree copy may not match.
+	FetchFileAtRef(ctx context.Context, in *FetchFileAtRefRequest, opts ...grpc.CallOption) (*FetchFileAtRefResponse, error)
 }
 
 type codeWalkerClient struct {
@@ -219,6 +224,16 @@ func (c *codeWalkerClient) ListPullRequests(ctx context.Context, in *ListPullReq
 	return out, nil
 }
 
+func (c *codeWalkerClient) FetchFileAtRef(ctx context.Context, in *FetchFileAtRefRequest, opts ...grpc.CallOption) (*FetchFileAtRefResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(FetchFileAtRefResponse)
+	err := c.cc.Invoke(ctx, CodeWalker_FetchFileAtRef_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CodeWalkerServer is the server API for CodeWalker service.
 // All implementations should embed UnimplementedCodeWalkerServer
 // for forward compatibility.
@@ -252,6 +267,10 @@ type CodeWalkerServer interface {
 	// List open pull requests for a repository.
 	// Used by clients to populate a PR picker.
 	ListPullRequests(context.Context, *ListPullRequestsRequest) (*ListPullRequestsResponse, error)
+	// Fetch a file's content at a specific ref via the appropriate forge.
+	// Used by clients to display the head-ref version of a file during a
+	// review session, where the working-tree copy may not match.
+	FetchFileAtRef(context.Context, *FetchFileAtRefRequest) (*FetchFileAtRefResponse, error)
 }
 
 // UnimplementedCodeWalkerServer should be embedded to have
@@ -290,6 +309,9 @@ func (UnimplementedCodeWalkerServer) ListFileOrderers(context.Context, *ListFile
 }
 func (UnimplementedCodeWalkerServer) ListPullRequests(context.Context, *ListPullRequestsRequest) (*ListPullRequestsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListPullRequests not implemented")
+}
+func (UnimplementedCodeWalkerServer) FetchFileAtRef(context.Context, *FetchFileAtRefRequest) (*FetchFileAtRefResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method FetchFileAtRef not implemented")
 }
 func (UnimplementedCodeWalkerServer) testEmbeddedByValue() {}
 
@@ -456,6 +478,24 @@ func _CodeWalker_ListPullRequests_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _CodeWalker_FetchFileAtRef_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchFileAtRefRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CodeWalkerServer).FetchFileAtRef(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CodeWalker_FetchFileAtRef_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CodeWalkerServer).FetchFileAtRef(ctx, req.(*FetchFileAtRefRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // CodeWalker_ServiceDesc is the grpc.ServiceDesc for CodeWalker service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -482,6 +522,10 @@ var CodeWalker_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListPullRequests",
 			Handler:    _CodeWalker_ListPullRequests_Handler,
+		},
+		{
+			MethodName: "FetchFileAtRef",
+			Handler:    _CodeWalker_FetchFileAtRef_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/proto/codewalker/v1/codewalker.proto
+++ b/proto/codewalker/v1/codewalker.proto
@@ -47,6 +47,11 @@ service CodeWalker {
   // List open pull requests for a repository.
   // Used by clients to populate a PR picker.
   rpc ListPullRequests(ListPullRequestsRequest) returns (ListPullRequestsResponse);
+
+  // Fetch a file's content at a specific ref via the appropriate forge.
+  // Used by clients to display the head-ref version of a file during a
+  // review session, where the working-tree copy may not match.
+  rpc FetchFileAtRef(FetchFileAtRefRequest) returns (FetchFileAtRefResponse);
 }
 
 // ─────────────────────────────────────────────
@@ -535,4 +540,29 @@ message PullRequestSummary {
   string title  = 2;
   string author = 3;
   string url    = 4;
+}
+
+message FetchFileAtRefRequest {
+  // Forge host. Canonical form per forge.NormalizeHost.
+  string host = 1;
+
+  // Repository owner.
+  string owner = 2;
+
+  // Repository name.
+  string repo = 3;
+
+  // File path relative to the repo root.
+  string path = 4;
+
+  // Git ref (commit SHA, branch, or tag).
+  string ref = 5;
+
+  // Optional forge token. Empty means unauthenticated.
+  string forge_token = 6;
+}
+
+message FetchFileAtRefResponse {
+  // Raw file content as returned by the forge.
+  bytes content = 1;
 }

--- a/server/fetch_file_at_ref.go
+++ b/server/fetch_file_at_ref.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"context"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	_ "github.com/yourorg/codewalker/internal/forge/forges"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FetchFileAtRef implements CodeWalkerServer.FetchFileAtRef.
+func (s *Server) FetchFileAtRef(ctx context.Context, req *v1.FetchFileAtRefRequest) (*v1.FetchFileAtRefResponse, error) {
+	host := forge.NormalizeHost(req.Host)
+	if host == "" || req.Owner == "" || req.Repo == "" || req.Path == "" || req.Ref == "" {
+		return nil, status.Error(codes.InvalidArgument, "host, owner, repo, path, and ref are required")
+	}
+
+	handler, err := forge.Resolve(host)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unsupported forge host %q: %v", host, err)
+	}
+
+	fc := &forge.ForgeContext{
+		Forge: "github",
+		Owner: req.Owner,
+		Repo:  req.Repo,
+	}
+
+	content, err := handler.FetchFile(ctx, fc, req.Path, req.Ref, req.ForgeToken)
+	if err != nil {
+		return nil, forgeErrToStatus(err, "fetch file")
+	}
+
+	return &v1.FetchFileAtRefResponse{Content: content}, nil
+}

--- a/server/fetch_file_at_ref_test.go
+++ b/server/fetch_file_at_ref_test.go
@@ -1,0 +1,307 @@
+package server_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	"github.com/yourorg/codewalker/internal/session"
+	"github.com/yourorg/codewalker/server"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fetchMockForgeHandler is a configurable forge handler used to drive
+// FetchFileAtRef tests. Behaviour is set per-test via package-level vars.
+type fetchMockForgeHandler struct{}
+
+var (
+	fetchFileContent  []byte
+	fetchFileErr      error
+	fetchFileGotPath  string
+	fetchFileGotRef   string
+	fetchFileGotToken string
+	fetchFileGotOwner string
+	fetchFileGotRepo  string
+)
+
+func (f *fetchMockForgeHandler) Hosts() []string { return []string{"fetch.example.com"} }
+
+func (f *fetchMockForgeHandler) ParseURL(string) (*forge.ForgeContext, error) {
+	return nil, nil
+}
+
+func (f *fetchMockForgeHandler) FetchReview(context.Context, *forge.ForgeContext, string) (*forge.ReviewPayload, error) {
+	return nil, nil
+}
+
+func (f *fetchMockForgeHandler) FetchFile(_ context.Context, fc *forge.ForgeContext, path, ref, token string) ([]byte, error) {
+	fetchFileGotPath = path
+	fetchFileGotRef = ref
+	fetchFileGotToken = token
+	if fc != nil {
+		fetchFileGotOwner = fc.Owner
+		fetchFileGotRepo = fc.Repo
+	}
+	if fetchFileErr != nil {
+		return nil, fetchFileErr
+	}
+	return fetchFileContent, nil
+}
+
+func (f *fetchMockForgeHandler) ListPullRequests(context.Context, string, string, string) ([]*forge.PullRequest, error) {
+	return nil, nil
+}
+
+func init() {
+	forge.Register(&fetchMockForgeHandler{})
+}
+
+func resetFetchMock() {
+	fetchFileContent = nil
+	fetchFileErr = nil
+	fetchFileGotPath = ""
+	fetchFileGotRef = ""
+	fetchFileGotToken = ""
+	fetchFileGotOwner = ""
+	fetchFileGotRepo = ""
+}
+
+func TestFetchFileAtRef_Success(t *testing.T) {
+	resetFetchMock()
+	fetchFileContent = []byte("package main\n")
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	resp, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:       "fetch.example.com",
+		Owner:      "owner",
+		Repo:       "repo",
+		Path:       "main.go",
+		Ref:        "abc123",
+		ForgeToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("FetchFileAtRef: %v", err)
+	}
+	if string(resp.Content) != "package main\n" {
+		t.Errorf("content = %q, want %q", resp.Content, "package main\n")
+	}
+	if fetchFileGotPath != "main.go" {
+		t.Errorf("path passed to handler = %q, want %q", fetchFileGotPath, "main.go")
+	}
+	if fetchFileGotRef != "abc123" {
+		t.Errorf("ref passed to handler = %q, want %q", fetchFileGotRef, "abc123")
+	}
+	if fetchFileGotToken != "tok" {
+		t.Errorf("token passed to handler = %q, want %q", fetchFileGotToken, "tok")
+	}
+	if fetchFileGotOwner != "owner" {
+		t.Errorf("owner passed to handler = %q, want %q", fetchFileGotOwner, "owner")
+	}
+	if fetchFileGotRepo != "repo" {
+		t.Errorf("repo passed to handler = %q, want %q", fetchFileGotRepo, "repo")
+	}
+}
+
+func TestFetchFileAtRef_EmptyTokenPublicRepo(t *testing.T) {
+	resetFetchMock()
+	fetchFileContent = []byte("public content")
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	resp, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:  "fetch.example.com",
+		Owner: "owner",
+		Repo:  "repo",
+		Path:  "README.md",
+		Ref:   "main",
+	})
+	if err != nil {
+		t.Fatalf("FetchFileAtRef: %v", err)
+	}
+	if string(resp.Content) != "public content" {
+		t.Errorf("content = %q, want %q", resp.Content, "public content")
+	}
+	if fetchFileGotToken != "" {
+		t.Errorf("expected empty token forwarded, got %q", fetchFileGotToken)
+	}
+}
+
+func TestFetchFileAtRef_HostNormalised(t *testing.T) {
+	resetFetchMock()
+	fetchFileContent = []byte("ok")
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	resp, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:  "Fetch.Example.COM/",
+		Owner: "owner",
+		Repo:  "repo",
+		Path:  "main.go",
+		Ref:   "main",
+	})
+	if err != nil {
+		t.Fatalf("FetchFileAtRef: %v", err)
+	}
+	if string(resp.Content) != "ok" {
+		t.Errorf("content = %q, want %q", resp.Content, "ok")
+	}
+}
+
+func TestFetchFileAtRef_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *v1.FetchFileAtRefRequest
+	}{
+		{
+			name: "missing host",
+			req:  &v1.FetchFileAtRefRequest{Owner: "o", Repo: "r", Path: "p", Ref: "ref"},
+		},
+		{
+			name: "missing owner",
+			req:  &v1.FetchFileAtRefRequest{Host: "fetch.example.com", Repo: "r", Path: "p", Ref: "ref"},
+		},
+		{
+			name: "missing repo",
+			req:  &v1.FetchFileAtRefRequest{Host: "fetch.example.com", Owner: "o", Path: "p", Ref: "ref"},
+		},
+		{
+			name: "missing path",
+			req:  &v1.FetchFileAtRefRequest{Host: "fetch.example.com", Owner: "o", Repo: "r", Ref: "ref"},
+		},
+		{
+			name: "missing ref",
+			req:  &v1.FetchFileAtRefRequest{Host: "fetch.example.com", Owner: "o", Repo: "r", Path: "p"},
+		},
+	}
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFetchMock()
+			_, err := srv.FetchFileAtRef(context.Background(), tc.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("not a gRPC status: %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("code = %v, want InvalidArgument", st.Code())
+			}
+		})
+	}
+}
+
+func TestFetchFileAtRef_UnsupportedHost(t *testing.T) {
+	resetFetchMock()
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	_, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:  "unsupported.example.org",
+		Owner: "o",
+		Repo:  "r",
+		Path:  "p",
+		Ref:   "ref",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestFetchFileAtRef_AuthFailedPreservesDetail(t *testing.T) {
+	resetFetchMock()
+	fetchFileErr = &forge.Error{
+		Code:   forge.ErrCodeAuthFailed,
+		Msg:    "GitHub API auth failed (401 Unauthorized)",
+		Detail: `{"message":"Bad credentials"}`,
+	}
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	_, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:       "fetch.example.com",
+		Owner:      "owner",
+		Repo:       "repo",
+		Path:       "main.go",
+		Ref:        "main",
+		ForgeToken: "bad",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", st.Code())
+	}
+	if !strings.Contains(st.Message(), "Bad credentials") {
+		t.Errorf("status message missing detail: %q", st.Message())
+	}
+}
+
+func TestFetchFileAtRef_ForbiddenPreservesDetail(t *testing.T) {
+	resetFetchMock()
+	fetchFileErr = &forge.Error{
+		Code:   forge.ErrCodeAuthFailed,
+		Msg:    "GitHub API auth failed (403 Forbidden)",
+		Detail: `{"message":"Resource protected by organization SAML enforcement"}`,
+	}
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	_, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:       "fetch.example.com",
+		Owner:      "owner",
+		Repo:       "repo",
+		Path:       "main.go",
+		Ref:        "main",
+		ForgeToken: "tok",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", st.Code())
+	}
+	if !strings.Contains(st.Message(), "SAML") {
+		t.Errorf("status message missing detail: %q", st.Message())
+	}
+}
+
+func TestFetchFileAtRef_NotFound(t *testing.T) {
+	resetFetchMock()
+	fetchFileErr = &forge.Error{
+		Code: forge.ErrCodeNotFound,
+		Msg:  "GitHub API not found (404 Not Found)",
+	}
+
+	srv := server.New(session.NewStore(), &mockProvider{}, "")
+	_, err := srv.FetchFileAtRef(context.Background(), &v1.FetchFileAtRefRequest{
+		Host:  "fetch.example.com",
+		Owner: "owner",
+		Repo:  "repo",
+		Path:  "missing.go",
+		Ref:   "main",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}


### PR DESCRIPTION
Closes #60.

## Summary

Adds a new `FetchFileAtRef` RPC that exposes `ForgeHandler.FetchFile` directly to clients. The IntelliJ plugin will use this to render the PR's head-ref version of a file during review sessions, rather than the user's working-tree copy which may be a different version.

This is a non-breaking proto change. Tag `v0.6.0` after merge so JitPack can build the proto stubs.

## Changes

- **Proto** (`proto/codewalker/v1/codewalker.proto`): adds `FetchFileAtRef` RPC, `FetchFileAtRefRequest`, `FetchFileAtRefResponse`. Generated stubs regenerated via `make proto`.
- **Server** (`server/fetch_file_at_ref.go`): thin wrapper around `ForgeHandler.FetchFile`. Validates required fields, applies `forge.NormalizeHost` at handler entry, passes `req.ForgeToken` verbatim (no token resolution), maps forge errors via the existing `forgeErrToStatus`.
- **Tests** (`server/fetch_file_at_ref_test.go`): table-driven coverage for success, missing-field validation (one case per field), unsupported host, 401/403 with detail preserved, 404, empty-token public-repo case, and host normalisation.
- **Briefing**: appends a bullet under Development rules → Code documenting the RPC.

## Test plan

- [x] `make ci` passes (buf lint, go vet, go build, go test)
- [x] All new test cases pass
- [x] Existing tests still pass
- [x] Briefing updated; README unaffected (no developer-facing install/run change)

https://claude.ai/code/session_012QFFD89bnVdJM95XU1WzAi

---
_Generated by [Claude Code](https://claude.ai/code/session_012QFFD89bnVdJM95XU1WzAi)_