### PR TITLE
fix: emit ReviewReady.steps in Forward order

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -293,6 +293,20 @@ existing code.
 - github.com/{owner}/{repo}/commit/{sha}         → commit
 - github.com/{owner}/{repo}/compare/{base}...{head} → comparison
 
+### Step ordering on the wire
+
+`ReviewReady.steps` is emitted in Forward traversal order — the same order
+the navigation chain follows when calling `Navigate(Forward)` repeatedly
+from `entry_step_id`. Order is determined by the file orderer
+(default: `entry-points-first`) over `payload.Files`, then by parser order
+of hunks within each file. Clients can render the step list in wire
+order and trust that it matches navigation order.
+
+`graph.Graph.AllSteps()` iterates the underlying map and is therefore
+non-deterministic — never use it for proto emission. Capture the desired
+order explicitly at graph-build time (see `buildHunkGraph`'s
+`orderedStepIDs` return value) and iterate that slice instead.
+
 ### Not in scope for v1
 - OAuth flow — use gh CLI token or manual token entry
 - GitLab, Gitea, Bitbucket forge handlers

--- a/server/open_review_session.go
+++ b/server/open_review_session.go
@@ -90,7 +90,7 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 		return err
 	}
 
-	g, fileEntryStepIDs := buildHunkGraph(payload.Files, fileLines, req.OmitRawSource)
+	g, fileEntryStepIDs, orderedStepIDs := buildHunkGraph(payload.Files, fileLines, req.OmitRawSource)
 	slog.Debug("hunk graph built", "step_count", g.Len(), "entry_step_id", g.EntryID)
 
 	// --- Step 4: extract glossary ---
@@ -146,7 +146,7 @@ outer:
 
 	// --- Step 6: emit ReviewReady ---
 	forgeCtxProto := toProtoForgeContext(fc, payload.Files, fileEntryStepIDs)
-	steps := protoReviewSteps(g)
+	steps := protoReviewSteps(g, orderedStepIDs)
 
 	return send(stream, &v1.SessionEvent{
 		Event: &v1.SessionEvent_ReviewReady{
@@ -165,9 +165,16 @@ outer:
 
 const hunkContextLines = 5
 
-func buildHunkGraph(files []*forge.ReviewFile, fileLines map[string][]string, omitRaw bool) (*graph.Graph, map[string]string) {
+// buildHunkGraph builds the review-session step graph and returns it alongside
+// per-file entry step IDs and an ordered slice of step IDs in Forward
+// traversal order. The Forward order matches the file orderer's output, then
+// hunk parser order within each file — the same iteration order that wires
+// the NEXT edges, so callers can use it to emit ReviewReady.steps
+// deterministically.
+func buildHunkGraph(files []*forge.ReviewFile, fileLines map[string][]string, omitRaw bool) (*graph.Graph, map[string]string, []string) {
 	g := graph.NewGraph()
 	fileEntryStepIDs := make(map[string]string)
+	var orderedStepIDs []string
 
 	var prevStep *graph.Step
 
@@ -198,6 +205,7 @@ func buildHunkGraph(files []*forge.ReviewFile, fileLines map[string][]string, om
 				HunkSpan: hunkSpan,
 			}
 			g.Add(step)
+			orderedStepIDs = append(orderedStepIDs, id)
 
 			if _, ok := fileEntryStepIDs[file.Path]; !ok {
 				fileEntryStepIDs[file.Path] = id
@@ -217,7 +225,7 @@ func buildHunkGraph(files []*forge.ReviewFile, fileLines map[string][]string, om
 		}
 	}
 
-	return g, fileEntryStepIDs
+	return g, fileEntryStepIDs, orderedStepIDs
 }
 
 func extractContextLines(lines []string, start, end int) string {
@@ -233,10 +241,17 @@ func extractContextLines(lines []string, start, end int) string {
 	return strings.Join(lines[start:end], "\n")
 }
 
-func protoReviewSteps(g *graph.Graph) []*v1.Step {
-	all := g.AllSteps()
-	out := make([]*v1.Step, 0, len(all))
-	for _, s := range all {
+// protoReviewSteps emits steps in Forward traversal order using the
+// orderedIDs slice produced by buildHunkGraph. This guarantees that
+// ReviewReady.steps matches the order Navigate(Forward) follows from the
+// entry step.
+func protoReviewSteps(g *graph.Graph, orderedIDs []string) []*v1.Step {
+	out := make([]*v1.Step, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		s, ok := g.Step(id)
+		if !ok {
+			continue
+		}
 		out = append(out, &v1.Step{
 			Id:       s.ID,
 			Label:    s.Label,

--- a/server/open_review_session_step_order_test.go
+++ b/server/open_review_session_step_order_test.go
@@ -1,0 +1,156 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/forge"
+	_ "github.com/yourorg/codewalker/internal/forge/orderers"
+	"github.com/yourorg/codewalker/internal/session"
+	"github.com/yourorg/codewalker/server"
+)
+
+// stepOrderForgeHandler exposes 5 files with 3 hunks each so map iteration
+// order is statistically extremely unlikely to coincide with the expected
+// Forward traversal order.
+type stepOrderForgeHandler struct{}
+
+func (m *stepOrderForgeHandler) Hosts() []string { return []string{"steporder.example.com"} }
+
+func (m *stepOrderForgeHandler) ParseURL(rawURL string) (*forge.ForgeContext, error) {
+	return &forge.ForgeContext{
+		Kind:     forge.ForgeContextKindPR,
+		Forge:    "mock-step-order",
+		Owner:    "owner",
+		Repo:     "repo",
+		PRNumber: 1,
+		BaseRef:  "main",
+		HeadRef:  "feature",
+		URL:      rawURL,
+	}, nil
+}
+
+func (m *stepOrderForgeHandler) FetchReview(_ context.Context, fc *forge.ForgeContext, _ string) (*forge.ReviewPayload, error) {
+	mkHunk := func(newStart int) *forge.Hunk {
+		return &forge.Hunk{
+			OldStart: newStart, OldLines: 1,
+			NewStart: newStart, NewLines: 1,
+			RawDiff: fmt.Sprintf("@@ -%d +%d @@\n-old\n+new\n", newStart, newStart),
+		}
+	}
+	mkFile := func(path string) *forge.ReviewFile {
+		return &forge.ReviewFile{
+			Path: path, Language: "go", ChangeKind: "MODIFIED",
+			Hunks: []*forge.Hunk{mkHunk(10), mkHunk(50), mkHunk(100)},
+		}
+	}
+	return &forge.ReviewPayload{
+		Context: fc,
+		Files: []*forge.ReviewFile{
+			mkFile("aaa/file_a.go"),
+			mkFile("bbb/file_b.go"),
+			mkFile("ccc/file_c.go"),
+			mkFile("ddd/file_d.go"),
+			mkFile("eee/file_e.go"),
+		},
+	}, nil
+}
+
+func (m *stepOrderForgeHandler) FetchFile(_ context.Context, _ *forge.ForgeContext, _, _, _ string) ([]byte, error) {
+	return []byte("line\n"), nil
+}
+
+func (m *stepOrderForgeHandler) ListPullRequests(_ context.Context, _, _, _ string) ([]*forge.PullRequest, error) {
+	return nil, nil
+}
+
+func init() {
+	forge.Register(&stepOrderForgeHandler{})
+}
+
+func TestReviewReady_StepsAreInForwardOrder(t *testing.T) {
+	// Run repeatedly: map iteration order in Go is randomised per run, so
+	// any residual reliance on it would surface across iterations.
+	const iterations = 20
+
+	expected := []string{
+		"hunk:aaa/file_a.go:10", "hunk:aaa/file_a.go:50", "hunk:aaa/file_a.go:100",
+		"hunk:bbb/file_b.go:10", "hunk:bbb/file_b.go:50", "hunk:bbb/file_b.go:100",
+		"hunk:ccc/file_c.go:10", "hunk:ccc/file_c.go:50", "hunk:ccc/file_c.go:100",
+		"hunk:ddd/file_d.go:10", "hunk:ddd/file_d.go:50", "hunk:ddd/file_d.go:100",
+		"hunk:eee/file_e.go:10", "hunk:eee/file_e.go:50", "hunk:eee/file_e.go:100",
+	}
+
+	for i := 0; i < iterations; i++ {
+		store := session.NewStore()
+		srv := server.New(store, &mockProvider{}, "")
+
+		stream := &mockSessionStream{ctx: context.Background()}
+		if err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+			Url:          "https://steporder.example.com/owner/repo/pull/1",
+			FileOrdering: "alphabetical",
+		}, stream); err != nil {
+			t.Fatalf("iteration %d: OpenReviewSession: %v", i, err)
+		}
+
+		rr := stream.events[len(stream.events)-1].GetReviewReady()
+		if rr == nil {
+			t.Fatalf("iteration %d: no ReviewReady event", i)
+		}
+
+		if len(rr.Steps) != len(expected) {
+			t.Fatalf("iteration %d: got %d steps, want %d", i, len(rr.Steps), len(expected))
+		}
+		for j, want := range expected {
+			if rr.Steps[j].Id != want {
+				t.Errorf("iteration %d: step %d id = %q, want %q", i, j, rr.Steps[j].Id, want)
+			}
+		}
+
+		if rr.EntryStepId != expected[0] {
+			t.Errorf("iteration %d: entry_step_id = %q, want %q", i, rr.EntryStepId, expected[0])
+		}
+
+		// Walk the graph by following NEXT edges from the entry step and
+		// confirm the navigation chain matches wire order.
+		got := []string{rr.EntryStepId}
+		cur := rr.EntryStepId
+		for k := 1; k < len(expected); k++ {
+			step := findStep(rr.Steps, cur)
+			if step == nil {
+				t.Fatalf("iteration %d: step %q not present in ReviewReady.steps", i, cur)
+			}
+			next := nextNavigableTarget(step)
+			if next == "" {
+				t.Fatalf("iteration %d: no NEXT edge from %q (position %d)", i, cur, k-1)
+			}
+			got = append(got, next)
+			cur = next
+		}
+		for k, want := range expected {
+			if got[k] != want {
+				t.Errorf("iteration %d: forward chain pos %d = %q, want %q", i, k, got[k], want)
+			}
+		}
+	}
+}
+
+func findStep(steps []*v1.Step, id string) *v1.Step {
+	for _, s := range steps {
+		if s.Id == id {
+			return s
+		}
+	}
+	return nil
+}
+
+func nextNavigableTarget(s *v1.Step) string {
+	for _, e := range s.Edges {
+		if e.Label == v1.EdgeLabel_EDGE_LABEL_NEXT && e.Navigable {
+			return e.TargetStepId
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Fixes #63. `ReviewReady.steps` was being emitted in Go map iteration order (via `Graph.AllSteps()`), which is non-deterministic across runs and unrelated to the `Forward` navigation chain. Clients that render the step list in wire order saw it shuffle randomly per session and almost never match navigation order.

## Changes

- **`server/open_review_session.go`**
  - `buildHunkGraph` now also returns an `orderedStepIDs []string` slice, populated in the same loop that wires the `NEXT` edges. This is the Forward chain order by construction (file orderer output, then parser order of hunks within each file).
  - `protoReviewSteps(g, orderedIDs)` iterates that slice — using the existing `Graph.Step(id)` accessor — instead of `Graph.AllSteps()`.
  - The walkthrough-session `protoSteps` path in `open_session.go` is left alone; the issue scoped the fix to the review path and there is no client-visible bug there today.
- **`server/open_review_session_step_order_test.go` (new)** — registers a 5-file × 3-hunk mock forge handler and asserts that `ReviewReady.Steps` arrives in the expected order across 20 iterations (Go randomises map iteration per run, so any residual non-determinism would surface). Also walks the graph by following `NEXT` edges from `EntryStepID` and asserts the chain matches wire order.
- **`codewalker-briefing.md`** — documents the new ordering contract and warns against using `Graph.AllSteps()` for proto emission.

## Test plan

- [x] `make ci` passes (buf lint, go vet, build, full test suite)
- [x] New test passes with `-count=5`
- [x] Existing review-session tests (including ordering tests) still pass

https://claude.ai/code/session_01KRzbfBuJxXqUaA7QXp4uTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRzbfBuJxXqUaA7QXp4uTQ)_