### PR TITLE
feat: add head_ref to PullRequestSummary

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -421,7 +421,10 @@ Read from environment variables. No config files in v1.
   vs "token expired") without a second round trip.
 - ForgeHandler implementations must support listing open pull requests via
   `ListPullRequests(ctx, owner, repo, token)` so clients can build PR
-  pickers without hardcoding forge-specific API calls.
+  pickers without hardcoding forge-specific API calls. `PullRequest.HeadRef`
+  carries the head branch name and is surfaced through `PullRequestSummary.head_ref`
+  so clients can check working-tree state (e.g. dirty checkout) before paying
+  the cost of `OpenReviewSession`.
 - ForgeHandler implementations support fetching arbitrary file content at
   a ref via FetchFile. The FetchFileAtRef RPC exposes this directly to
   clients so review session views can render the PR's head-ref version

--- a/gen/codewalker/v1/codewalker.pb.go
+++ b/gen/codewalker/v1/codewalker.pb.go
@@ -3092,11 +3092,14 @@ func (x *ListPullRequestsResponse) GetPullRequests() []*PullRequestSummary {
 }
 
 type PullRequestSummary struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Number        int32                  `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
-	Title         string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
-	Author        string                 `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
-	Url           string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Number int32                  `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
+	Title  string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	Author string                 `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
+	Url    string                 `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	// The PR's head branch name (e.g. "feature/foo"). Used by clients to
+	// operate on the working tree before opening a review session.
+	HeadRef       string `protobuf:"bytes,5,opt,name=head_ref,json=headRef,proto3" json:"head_ref,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3155,6 +3158,13 @@ func (x *PullRequestSummary) GetAuthor() string {
 func (x *PullRequestSummary) GetUrl() string {
 	if x != nil {
 		return x.Url
+	}
+	return ""
+}
+
+func (x *PullRequestSummary) GetHeadRef() string {
+	if x != nil {
+		return x.HeadRef
 	}
 	return ""
 }
@@ -3501,12 +3511,13 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\vforge_token\x18\x04 \x01(\tR\n" +
 	"forgeToken\"b\n" +
 	"\x18ListPullRequestsResponse\x12F\n" +
-	"\rpull_requests\x18\x01 \x03(\v2!.codewalker.v1.PullRequestSummaryR\fpullRequests\"l\n" +
+	"\rpull_requests\x18\x01 \x03(\v2!.codewalker.v1.PullRequestSummaryR\fpullRequests\"\x87\x01\n" +
 	"\x12PullRequestSummary\x12\x16\n" +
 	"\x06number\x18\x01 \x01(\x05R\x06number\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x16\n" +
 	"\x06author\x18\x03 \x01(\tR\x06author\x12\x10\n" +
-	"\x03url\x18\x04 \x01(\tR\x03url\"\x9c\x01\n" +
+	"\x03url\x18\x04 \x01(\tR\x03url\x12\x19\n" +
+	"\bhead_ref\x18\x05 \x01(\tR\aheadRef\"\x9c\x01\n" +
 	"\x15FetchFileAtRefRequest\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x14\n" +
 	"\x05owner\x18\x02 \x01(\tR\x05owner\x12\x12\n" +

--- a/internal/forge/forges/github.go
+++ b/internal/forge/forges/github.go
@@ -155,6 +155,9 @@ func (g *githubHandler) ListPullRequests(ctx context.Context, owner, repo, token
 		User    struct {
 			Login string `json:"login"`
 		} `json:"user"`
+		Head struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
 		return nil, fmt.Errorf("decode pull request list response: %w", err)
@@ -163,10 +166,11 @@ func (g *githubHandler) ListPullRequests(ctx context.Context, owner, repo, token
 	out := make([]*forge.PullRequest, 0, len(items))
 	for _, it := range items {
 		out = append(out, &forge.PullRequest{
-			Number: it.Number,
-			Title:  it.Title,
-			Author: it.User.Login,
-			URL:    it.HTMLURL,
+			Number:  it.Number,
+			Title:   it.Title,
+			Author:  it.User.Login,
+			URL:     it.HTMLURL,
+			HeadRef: it.Head.Ref,
 		})
 	}
 	return out, nil

--- a/internal/forge/forges/github_test.go
+++ b/internal/forge/forges/github_test.go
@@ -171,9 +171,9 @@ func TestParseHunkRange(t *testing.T) {
 func TestListPullRequests(t *testing.T) {
 	const successBody = `[
 		{"number": 42, "title": "Add foo", "html_url": "https://github.com/octocat/hello-world/pull/42",
-		 "user": {"login": "alice"}},
+		 "user": {"login": "alice"}, "head": {"ref": "feature/foo"}},
 		{"number": 43, "title": "Fix bar", "html_url": "https://github.com/octocat/hello-world/pull/43",
-		 "user": {"login": "bob"}}
+		 "user": {"login": "bob"}, "head": {"ref": "fix/bar"}}
 	]`
 	const samlBody = `{"message":"Resource protected by organization SAML enforcement","documentation_url":"https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on"}`
 	const badCredsBody = `{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`
@@ -200,10 +200,11 @@ func TestListPullRequests(t *testing.T) {
 			wantAuthHdr: "Bearer ghp_secret",
 			checkResults: func(t *testing.T, prs []*forge.PullRequest) {
 				if prs[0].Number != 42 || prs[0].Title != "Add foo" || prs[0].Author != "alice" ||
-					prs[0].URL != "https://github.com/octocat/hello-world/pull/42" {
+					prs[0].URL != "https://github.com/octocat/hello-world/pull/42" ||
+					prs[0].HeadRef != "feature/foo" {
 					t.Errorf("PR[0] = %+v", prs[0])
 				}
-				if prs[1].Number != 43 || prs[1].Author != "bob" {
+				if prs[1].Number != 43 || prs[1].Author != "bob" || prs[1].HeadRef != "fix/bar" {
 					t.Errorf("PR[1] = %+v", prs[1])
 				}
 			},

--- a/internal/forge/handler.go
+++ b/internal/forge/handler.go
@@ -30,8 +30,9 @@ type ForgeHandler interface {
 
 // PullRequest is a forge-agnostic summary of an open pull request.
 type PullRequest struct {
-	Number int
-	Title  string
-	Author string
-	URL    string
+	Number  int
+	Title   string
+	Author  string
+	URL     string
+	HeadRef string
 }

--- a/proto/codewalker/v1/codewalker.proto
+++ b/proto/codewalker/v1/codewalker.proto
@@ -540,6 +540,10 @@ message PullRequestSummary {
   string title  = 2;
   string author = 3;
   string url    = 4;
+
+  // The PR's head branch name (e.g. "feature/foo"). Used by clients to
+  // operate on the working tree before opening a review session.
+  string head_ref = 5;
 }
 
 message FetchFileAtRefRequest {

--- a/server/list_pull_requests.go
+++ b/server/list_pull_requests.go
@@ -30,10 +30,11 @@ func (s *Server) ListPullRequests(ctx context.Context, req *v1.ListPullRequestsR
 	out := make([]*v1.PullRequestSummary, 0, len(prs))
 	for _, p := range prs {
 		out = append(out, &v1.PullRequestSummary{
-			Number: int32(p.Number),
-			Title:  p.Title,
-			Author: p.Author,
-			Url:    p.URL,
+			Number:  int32(p.Number),
+			Title:   p.Title,
+			Author:  p.Author,
+			Url:     p.URL,
+			HeadRef: p.HeadRef,
 		})
 	}
 	return &v1.ListPullRequestsResponse{PullRequests: out}, nil


### PR DESCRIPTION
## Summary

Adds the PR head branch name to `PullRequestSummary` so clients can check working-tree state (e.g. dirty checkout) before paying the cost of `OpenReviewSession` (~16s). GitHub's `/pulls` endpoint already returns `head.ref` on every PR, so no extra API call is needed. Non-breaking proto addition.

## Changes

- `proto/codewalker/v1/codewalker.proto` — add `head_ref` (field 5) to `PullRequestSummary`
- `internal/forge/handler.go` — add `HeadRef` to `forge.PullRequest`
- `internal/forge/forges/github.go` — decode `head.ref` from the GitHub list response and copy it through
- `internal/forge/forges/github_test.go` — extend `TestListPullRequests` success fixture to assert `HeadRef`
- `server/list_pull_requests.go` — map `HeadRef` from `forge.PullRequest` to `v1.PullRequestSummary`
- `gen/codewalker/v1/codewalker.pb.go` — regenerated via `make proto`
- `codewalker-briefing.md` — note the new field on `PullRequestSummary`

## Test plan

- [x] `make ci` passes (buf lint, go vet, go build, go test)
- [x] `TestListPullRequests` asserts `HeadRef` is populated for both PRs in the success case

Closes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_013rVz9TmtGNFM6QUnewETQQ)_