### PR TITLE
feat: send summary early; remove glossary call

### DIFF
--- a/codewalker-briefing.md
+++ b/codewalker-briefing.md
@@ -111,8 +111,17 @@ truth. Key messages:
   `ExternalCallInfo` (only set when navigable = false)
 - `ExternalCallInfo` — package_name, symbol_name, llm_summary (always set),
   docs_url, source_url, version (last three best-effort only)
-- `NarrateEvent` (streamed) — token stream → `StepComplete` (new glossary
-  terms, available edges, breadcrumb)
+- `NarrateEvent` (streamed) — A successful Navigate stream emits:
+  - Zero or more `NarrateEvent.token` events as narration text streams from
+    the LLM.
+  - One `NarrateEvent.summary_ready` event as soon as the structured summary
+    is available — typically before narration finishes, so the reviewer
+    sees risk/breaking/tests early. Only emitted for steps that produce a
+    summary (review-session hunk steps in v1).
+  - One terminal `NarrateEvent.complete` event carrying the breadcrumb,
+    available edges, step id, and (for backward compatibility) the summary
+    again. New clients should prefer `summary_ready` when present; old
+    clients continue to read `Complete.summary`.
 - `RephraseRequest` — session_id + RephraseMode (SIMPLER/DEEPER/ANALOGY/TLDR)
 - `GlossaryTerm` — term, definition, step_id, TermKind
   (LANGUAGE/PATTERN/DOMAIN/LIBRARY)
@@ -406,6 +415,16 @@ Read from environment variables. No config files in v1.
   step proceeds with `summary = nil` and a debug log
 - Summary fields are always populated with "—" for non-applicable values rather
   than being absent. This guarantees clients can render a consistent layout
+- Navigate emits `NarrateEvent.summary_ready` the moment the summary channel
+  produces a non-nil summary, which is typically before narration finishes
+  streaming. The same summary is also placed on the terminal
+  `StepComplete.summary` for backward compatibility — old clients reading
+  only `complete` see no behavioural change. New clients should prefer
+  `summary_ready` to render summary fields without waiting for narration
+- `OpenReviewSession` does not produce a glossary. The `ReviewReady.glossary`
+  proto field is retained for backward compatibility but is always empty.
+  The glossary LLM call was removed because it added several seconds of
+  latency at session open and the only consumer never read the field
 - Forge handlers must not perform credential lookups. Tokens come from the
   request only. Anything that reads ambient credentials (env vars, config
   files, CLI tools) belongs in the client.

--- a/gen/codewalker/v1/codewalker.pb.go
+++ b/gen/codewalker/v1/codewalker.pb.go
@@ -1678,6 +1678,7 @@ type NarrateEvent struct {
 	//	*NarrateEvent_Token
 	//	*NarrateEvent_Complete
 	//	*NarrateEvent_Error
+	//	*NarrateEvent_SummaryReady
 	Event         isNarrateEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1747,6 +1748,15 @@ func (x *NarrateEvent) GetError() *ServiceError {
 	return nil
 }
 
+func (x *NarrateEvent) GetSummaryReady() *SummaryReady {
+	if x != nil {
+		if x, ok := x.Event.(*NarrateEvent_SummaryReady); ok {
+			return x.SummaryReady
+		}
+	}
+	return nil
+}
+
 type isNarrateEvent_Event interface {
 	isNarrateEvent_Event()
 }
@@ -1763,11 +1773,66 @@ type NarrateEvent_Error struct {
 	Error *ServiceError `protobuf:"bytes,3,opt,name=error,proto3,oneof"`
 }
 
+type NarrateEvent_SummaryReady struct {
+	SummaryReady *SummaryReady `protobuf:"bytes,4,opt,name=summary_ready,json=summaryReady,proto3,oneof"` // Structured summary, sent as soon as available
+}
+
 func (*NarrateEvent_Token) isNarrateEvent_Event() {}
 
 func (*NarrateEvent_Complete) isNarrateEvent_Event() {}
 
 func (*NarrateEvent_Error) isNarrateEvent_Event() {}
+
+func (*NarrateEvent_SummaryReady) isNarrateEvent_Event() {}
+
+// Emitted by Navigate as soon as the structured summary is available, which is
+// typically before narration tokens finish streaming. New clients should
+// prefer this over reading StepComplete.summary so the summary can render
+// without waiting for the full narration stream. StepComplete.summary
+// continues to be populated for backward compatibility.
+type SummaryReady struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Summary       *StepSummary           `protobuf:"bytes,1,opt,name=summary,proto3" json:"summary,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SummaryReady) Reset() {
+	*x = SummaryReady{}
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SummaryReady) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SummaryReady) ProtoMessage() {}
+
+func (x *SummaryReady) ProtoReflect() protoreflect.Message {
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SummaryReady.ProtoReflect.Descriptor instead.
+func (*SummaryReady) Descriptor() ([]byte, []int) {
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *SummaryReady) GetSummary() *StepSummary {
+	if x != nil {
+		return x.Summary
+	}
+	return nil
+}
 
 type NarrateToken struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1778,7 +1843,7 @@ type NarrateToken struct {
 
 func (x *NarrateToken) Reset() {
 	*x = NarrateToken{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[15]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1790,7 +1855,7 @@ func (x *NarrateToken) String() string {
 func (*NarrateToken) ProtoMessage() {}
 
 func (x *NarrateToken) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[15]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1803,7 +1868,7 @@ func (x *NarrateToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NarrateToken.ProtoReflect.Descriptor instead.
 func (*NarrateToken) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{15}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *NarrateToken) GetText() string {
@@ -1831,7 +1896,7 @@ type StepComplete struct {
 
 func (x *StepComplete) Reset() {
 	*x = StepComplete{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[16]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1843,7 +1908,7 @@ func (x *StepComplete) String() string {
 func (*StepComplete) ProtoMessage() {}
 
 func (x *StepComplete) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[16]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1856,7 +1921,7 @@ func (x *StepComplete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepComplete.ProtoReflect.Descriptor instead.
 func (*StepComplete) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{16}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *StepComplete) GetStepId() string {
@@ -1922,7 +1987,7 @@ type StepSummary struct {
 
 func (x *StepSummary) Reset() {
 	*x = StepSummary{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[17]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1934,7 +1999,7 @@ func (x *StepSummary) String() string {
 func (*StepSummary) ProtoMessage() {}
 
 func (x *StepSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[17]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1947,7 +2012,7 @@ func (x *StepSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepSummary.ProtoReflect.Descriptor instead.
 func (*StepSummary) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{17}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *StepSummary) GetBreaking() string {
@@ -2016,7 +2081,7 @@ type RephraseRequest struct {
 
 func (x *RephraseRequest) Reset() {
 	*x = RephraseRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[18]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2028,7 +2093,7 @@ func (x *RephraseRequest) String() string {
 func (*RephraseRequest) ProtoMessage() {}
 
 func (x *RephraseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[18]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2041,7 +2106,7 @@ func (x *RephraseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RephraseRequest.ProtoReflect.Descriptor instead.
 func (*RephraseRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{18}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RephraseRequest) GetSessionId() string {
@@ -2070,7 +2135,7 @@ type GlossaryTerm struct {
 
 func (x *GlossaryTerm) Reset() {
 	*x = GlossaryTerm{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[19]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2082,7 +2147,7 @@ func (x *GlossaryTerm) String() string {
 func (*GlossaryTerm) ProtoMessage() {}
 
 func (x *GlossaryTerm) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[19]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2095,7 +2160,7 @@ func (x *GlossaryTerm) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlossaryTerm.ProtoReflect.Descriptor instead.
 func (*GlossaryTerm) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{19}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GlossaryTerm) GetTerm() string {
@@ -2136,7 +2201,7 @@ type ExpandTermRequest struct {
 
 func (x *ExpandTermRequest) Reset() {
 	*x = ExpandTermRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[20]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2148,7 +2213,7 @@ func (x *ExpandTermRequest) String() string {
 func (*ExpandTermRequest) ProtoMessage() {}
 
 func (x *ExpandTermRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[20]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2161,7 +2226,7 @@ func (x *ExpandTermRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpandTermRequest.ProtoReflect.Descriptor instead.
 func (*ExpandTermRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{20}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ExpandTermRequest) GetSessionId() string {
@@ -2197,7 +2262,7 @@ type OpenReviewSessionRequest struct {
 
 func (x *OpenReviewSessionRequest) Reset() {
 	*x = OpenReviewSessionRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[21]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2274,7 @@ func (x *OpenReviewSessionRequest) String() string {
 func (*OpenReviewSessionRequest) ProtoMessage() {}
 
 func (x *OpenReviewSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[21]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2287,7 @@ func (x *OpenReviewSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenReviewSessionRequest.ProtoReflect.Descriptor instead.
 func (*OpenReviewSessionRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{21}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *OpenReviewSessionRequest) GetUrl() string {
@@ -2277,7 +2342,7 @@ type ReviewReady struct {
 
 func (x *ReviewReady) Reset() {
 	*x = ReviewReady{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[22]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2289,7 +2354,7 @@ func (x *ReviewReady) String() string {
 func (*ReviewReady) ProtoMessage() {}
 
 func (x *ReviewReady) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[22]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2302,7 +2367,7 @@ func (x *ReviewReady) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewReady.ProtoReflect.Descriptor instead.
 func (*ReviewReady) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{22}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ReviewReady) GetSessionId() string {
@@ -2375,7 +2440,7 @@ type ForgeContext struct {
 
 func (x *ForgeContext) Reset() {
 	*x = ForgeContext{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[23]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2387,7 +2452,7 @@ func (x *ForgeContext) String() string {
 func (*ForgeContext) ProtoMessage() {}
 
 func (x *ForgeContext) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[23]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2400,7 +2465,7 @@ func (x *ForgeContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForgeContext.ProtoReflect.Descriptor instead.
 func (*ForgeContext) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{23}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ForgeContext) GetKind() ForgeContextKind {
@@ -2502,7 +2567,7 @@ type ReviewFile struct {
 
 func (x *ReviewFile) Reset() {
 	*x = ReviewFile{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[24]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2514,7 +2579,7 @@ func (x *ReviewFile) String() string {
 func (*ReviewFile) ProtoMessage() {}
 
 func (x *ReviewFile) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[24]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2527,7 +2592,7 @@ func (x *ReviewFile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewFile.ProtoReflect.Descriptor instead.
 func (*ReviewFile) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{24}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ReviewFile) GetFilePath() string {
@@ -2595,7 +2660,7 @@ type HunkSpan struct {
 
 func (x *HunkSpan) Reset() {
 	*x = HunkSpan{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[25]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2607,7 +2672,7 @@ func (x *HunkSpan) String() string {
 func (*HunkSpan) ProtoMessage() {}
 
 func (x *HunkSpan) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[25]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2620,7 +2685,7 @@ func (x *HunkSpan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HunkSpan.ProtoReflect.Descriptor instead.
 func (*HunkSpan) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{25}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *HunkSpan) GetFilePath() string {
@@ -2690,7 +2755,7 @@ type ServiceError struct {
 
 func (x *ServiceError) Reset() {
 	*x = ServiceError{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[26]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2702,7 +2767,7 @@ func (x *ServiceError) String() string {
 func (*ServiceError) ProtoMessage() {}
 
 func (x *ServiceError) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[26]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2715,7 +2780,7 @@ func (x *ServiceError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServiceError.ProtoReflect.Descriptor instead.
 func (*ServiceError) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{26}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ServiceError) GetCode() ErrorCode {
@@ -2747,7 +2812,7 @@ type GetVersionRequest struct {
 
 func (x *GetVersionRequest) Reset() {
 	*x = GetVersionRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[27]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2759,7 +2824,7 @@ func (x *GetVersionRequest) String() string {
 func (*GetVersionRequest) ProtoMessage() {}
 
 func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[27]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2772,7 +2837,7 @@ func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionRequest.ProtoReflect.Descriptor instead.
 func (*GetVersionRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{27}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{28}
 }
 
 type GetVersionResponse struct {
@@ -2792,7 +2857,7 @@ type GetVersionResponse struct {
 
 func (x *GetVersionResponse) Reset() {
 	*x = GetVersionResponse{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[28]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2804,7 +2869,7 @@ func (x *GetVersionResponse) String() string {
 func (*GetVersionResponse) ProtoMessage() {}
 
 func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[28]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2817,7 +2882,7 @@ func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionResponse.ProtoReflect.Descriptor instead.
 func (*GetVersionResponse) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{28}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetVersionResponse) GetVersion() string {
@@ -2849,7 +2914,7 @@ type ListFileOrderersRequest struct {
 
 func (x *ListFileOrderersRequest) Reset() {
 	*x = ListFileOrderersRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[29]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2861,7 +2926,7 @@ func (x *ListFileOrderersRequest) String() string {
 func (*ListFileOrderersRequest) ProtoMessage() {}
 
 func (x *ListFileOrderersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[29]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2874,7 +2939,7 @@ func (x *ListFileOrderersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFileOrderersRequest.ProtoReflect.Descriptor instead.
 func (*ListFileOrderersRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{29}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{30}
 }
 
 type ListFileOrderersResponse struct {
@@ -2886,7 +2951,7 @@ type ListFileOrderersResponse struct {
 
 func (x *ListFileOrderersResponse) Reset() {
 	*x = ListFileOrderersResponse{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[30]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2898,7 +2963,7 @@ func (x *ListFileOrderersResponse) String() string {
 func (*ListFileOrderersResponse) ProtoMessage() {}
 
 func (x *ListFileOrderersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[30]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2911,7 +2976,7 @@ func (x *ListFileOrderersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFileOrderersResponse.ProtoReflect.Descriptor instead.
 func (*ListFileOrderersResponse) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{30}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListFileOrderersResponse) GetOrderers() []*FileOrderer {
@@ -2931,7 +2996,7 @@ type FileOrderer struct {
 
 func (x *FileOrderer) Reset() {
 	*x = FileOrderer{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[31]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2943,7 +3008,7 @@ func (x *FileOrderer) String() string {
 func (*FileOrderer) ProtoMessage() {}
 
 func (x *FileOrderer) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[31]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2956,7 +3021,7 @@ func (x *FileOrderer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileOrderer.ProtoReflect.Descriptor instead.
 func (*FileOrderer) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{31}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *FileOrderer) GetName() string {
@@ -2991,7 +3056,7 @@ type ListPullRequestsRequest struct {
 
 func (x *ListPullRequestsRequest) Reset() {
 	*x = ListPullRequestsRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3003,7 +3068,7 @@ func (x *ListPullRequestsRequest) String() string {
 func (*ListPullRequestsRequest) ProtoMessage() {}
 
 func (x *ListPullRequestsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[32]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3016,7 +3081,7 @@ func (x *ListPullRequestsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPullRequestsRequest.ProtoReflect.Descriptor instead.
 func (*ListPullRequestsRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{32}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListPullRequestsRequest) GetHost() string {
@@ -3056,7 +3121,7 @@ type ListPullRequestsResponse struct {
 
 func (x *ListPullRequestsResponse) Reset() {
 	*x = ListPullRequestsResponse{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3068,7 +3133,7 @@ func (x *ListPullRequestsResponse) String() string {
 func (*ListPullRequestsResponse) ProtoMessage() {}
 
 func (x *ListPullRequestsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[33]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3081,7 +3146,7 @@ func (x *ListPullRequestsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPullRequestsResponse.ProtoReflect.Descriptor instead.
 func (*ListPullRequestsResponse) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{33}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListPullRequestsResponse) GetPullRequests() []*PullRequestSummary {
@@ -3106,7 +3171,7 @@ type PullRequestSummary struct {
 
 func (x *PullRequestSummary) Reset() {
 	*x = PullRequestSummary{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3118,7 +3183,7 @@ func (x *PullRequestSummary) String() string {
 func (*PullRequestSummary) ProtoMessage() {}
 
 func (x *PullRequestSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[34]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3131,7 +3196,7 @@ func (x *PullRequestSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PullRequestSummary.ProtoReflect.Descriptor instead.
 func (*PullRequestSummary) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{34}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *PullRequestSummary) GetNumber() int32 {
@@ -3189,7 +3254,7 @@ type FetchFileAtRefRequest struct {
 
 func (x *FetchFileAtRefRequest) Reset() {
 	*x = FetchFileAtRefRequest{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3201,7 +3266,7 @@ func (x *FetchFileAtRefRequest) String() string {
 func (*FetchFileAtRefRequest) ProtoMessage() {}
 
 func (x *FetchFileAtRefRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[35]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3214,7 +3279,7 @@ func (x *FetchFileAtRefRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchFileAtRefRequest.ProtoReflect.Descriptor instead.
 func (*FetchFileAtRefRequest) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{35}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *FetchFileAtRefRequest) GetHost() string {
@@ -3269,7 +3334,7 @@ type FetchFileAtRefResponse struct {
 
 func (x *FetchFileAtRefResponse) Reset() {
 	*x = FetchFileAtRefResponse{}
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3346,7 @@ func (x *FetchFileAtRefResponse) String() string {
 func (*FetchFileAtRefResponse) ProtoMessage() {}
 
 func (x *FetchFileAtRefResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_codewalker_v1_codewalker_proto_msgTypes[36]
+	mi := &file_codewalker_v1_codewalker_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3359,7 @@ func (x *FetchFileAtRefResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchFileAtRefResponse.ProtoReflect.Descriptor instead.
 func (*FetchFileAtRefResponse) Descriptor() ([]byte, []int) {
-	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{36}
+	return file_codewalker_v1_codewalker_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *FetchFileAtRefResponse) GetContent() []byte {
@@ -3393,12 +3458,15 @@ const file_codewalker_v1_codewalker_proto_rawDesc = "" +
 	"\astep_id\x18\x03 \x01(\tH\x00R\x06stepId\x12;\n" +
 	"\vfollow_edge\x18\x04 \x01(\x0e2\x18.codewalker.v1.EdgeLabelH\x00R\n" +
 	"followEdgeB\r\n" +
-	"\vdestination\"\xbc\x01\n" +
+	"\vdestination\"\x80\x02\n" +
 	"\fNarrateEvent\x123\n" +
 	"\x05token\x18\x01 \x01(\v2\x1b.codewalker.v1.NarrateTokenH\x00R\x05token\x129\n" +
 	"\bcomplete\x18\x02 \x01(\v2\x1b.codewalker.v1.StepCompleteH\x00R\bcomplete\x123\n" +
-	"\x05error\x18\x03 \x01(\v2\x1b.codewalker.v1.ServiceErrorH\x00R\x05errorB\a\n" +
-	"\x05event\"\"\n" +
+	"\x05error\x18\x03 \x01(\v2\x1b.codewalker.v1.ServiceErrorH\x00R\x05error\x12B\n" +
+	"\rsummary_ready\x18\x04 \x01(\v2\x1b.codewalker.v1.SummaryReadyH\x00R\fsummaryReadyB\a\n" +
+	"\x05event\"D\n" +
+	"\fSummaryReady\x124\n" +
+	"\asummary\x18\x01 \x01(\v2\x1a.codewalker.v1.StepSummaryR\asummary\"\"\n" +
 	"\fNarrateToken\x12\x12\n" +
 	"\x04text\x18\x01 \x01(\tR\x04text\"\xf9\x01\n" +
 	"\fStepComplete\x12\x17\n" +
@@ -3628,7 +3696,7 @@ func file_codewalker_v1_codewalker_proto_rawDescGZIP() []byte {
 }
 
 var file_codewalker_v1_codewalker_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_codewalker_v1_codewalker_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(SessionKind)(0),                 // 0: codewalker.v1.SessionKind
 	(StepKind)(0),                    // 1: codewalker.v1.StepKind
@@ -3655,92 +3723,95 @@ var file_codewalker_v1_codewalker_proto_goTypes = []any{
 	(*SourceSpan)(nil),               // 22: codewalker.v1.SourceSpan
 	(*NavigateRequest)(nil),          // 23: codewalker.v1.NavigateRequest
 	(*NarrateEvent)(nil),             // 24: codewalker.v1.NarrateEvent
-	(*NarrateToken)(nil),             // 25: codewalker.v1.NarrateToken
-	(*StepComplete)(nil),             // 26: codewalker.v1.StepComplete
-	(*StepSummary)(nil),              // 27: codewalker.v1.StepSummary
-	(*RephraseRequest)(nil),          // 28: codewalker.v1.RephraseRequest
-	(*GlossaryTerm)(nil),             // 29: codewalker.v1.GlossaryTerm
-	(*ExpandTermRequest)(nil),        // 30: codewalker.v1.ExpandTermRequest
-	(*OpenReviewSessionRequest)(nil), // 31: codewalker.v1.OpenReviewSessionRequest
-	(*ReviewReady)(nil),              // 32: codewalker.v1.ReviewReady
-	(*ForgeContext)(nil),             // 33: codewalker.v1.ForgeContext
-	(*ReviewFile)(nil),               // 34: codewalker.v1.ReviewFile
-	(*HunkSpan)(nil),                 // 35: codewalker.v1.HunkSpan
-	(*ServiceError)(nil),             // 36: codewalker.v1.ServiceError
-	(*GetVersionRequest)(nil),        // 37: codewalker.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),       // 38: codewalker.v1.GetVersionResponse
-	(*ListFileOrderersRequest)(nil),  // 39: codewalker.v1.ListFileOrderersRequest
-	(*ListFileOrderersResponse)(nil), // 40: codewalker.v1.ListFileOrderersResponse
-	(*FileOrderer)(nil),              // 41: codewalker.v1.FileOrderer
-	(*ListPullRequestsRequest)(nil),  // 42: codewalker.v1.ListPullRequestsRequest
-	(*ListPullRequestsResponse)(nil), // 43: codewalker.v1.ListPullRequestsResponse
-	(*PullRequestSummary)(nil),       // 44: codewalker.v1.PullRequestSummary
-	(*FetchFileAtRefRequest)(nil),    // 45: codewalker.v1.FetchFileAtRefRequest
-	(*FetchFileAtRefResponse)(nil),   // 46: codewalker.v1.FetchFileAtRefResponse
+	(*SummaryReady)(nil),             // 25: codewalker.v1.SummaryReady
+	(*NarrateToken)(nil),             // 26: codewalker.v1.NarrateToken
+	(*StepComplete)(nil),             // 27: codewalker.v1.StepComplete
+	(*StepSummary)(nil),              // 28: codewalker.v1.StepSummary
+	(*RephraseRequest)(nil),          // 29: codewalker.v1.RephraseRequest
+	(*GlossaryTerm)(nil),             // 30: codewalker.v1.GlossaryTerm
+	(*ExpandTermRequest)(nil),        // 31: codewalker.v1.ExpandTermRequest
+	(*OpenReviewSessionRequest)(nil), // 32: codewalker.v1.OpenReviewSessionRequest
+	(*ReviewReady)(nil),              // 33: codewalker.v1.ReviewReady
+	(*ForgeContext)(nil),             // 34: codewalker.v1.ForgeContext
+	(*ReviewFile)(nil),               // 35: codewalker.v1.ReviewFile
+	(*HunkSpan)(nil),                 // 36: codewalker.v1.HunkSpan
+	(*ServiceError)(nil),             // 37: codewalker.v1.ServiceError
+	(*GetVersionRequest)(nil),        // 38: codewalker.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),       // 39: codewalker.v1.GetVersionResponse
+	(*ListFileOrderersRequest)(nil),  // 40: codewalker.v1.ListFileOrderersRequest
+	(*ListFileOrderersResponse)(nil), // 41: codewalker.v1.ListFileOrderersResponse
+	(*FileOrderer)(nil),              // 42: codewalker.v1.FileOrderer
+	(*ListPullRequestsRequest)(nil),  // 43: codewalker.v1.ListPullRequestsRequest
+	(*ListPullRequestsResponse)(nil), // 44: codewalker.v1.ListPullRequestsResponse
+	(*PullRequestSummary)(nil),       // 45: codewalker.v1.PullRequestSummary
+	(*FetchFileAtRefRequest)(nil),    // 46: codewalker.v1.FetchFileAtRefRequest
+	(*FetchFileAtRefResponse)(nil),   // 47: codewalker.v1.FetchFileAtRefResponse
 }
 var file_codewalker_v1_codewalker_proto_depIdxs = []int32{
 	8,  // 0: codewalker.v1.OpenSessionRequest.experience_level:type_name -> codewalker.v1.ExperienceLevel
 	12, // 1: codewalker.v1.SessionEvent.progress:type_name -> codewalker.v1.SessionProgress
 	13, // 2: codewalker.v1.SessionEvent.ready:type_name -> codewalker.v1.SessionReady
-	36, // 3: codewalker.v1.SessionEvent.error:type_name -> codewalker.v1.ServiceError
-	32, // 4: codewalker.v1.SessionEvent.review_ready:type_name -> codewalker.v1.ReviewReady
+	37, // 3: codewalker.v1.SessionEvent.error:type_name -> codewalker.v1.ServiceError
+	33, // 4: codewalker.v1.SessionEvent.review_ready:type_name -> codewalker.v1.ReviewReady
 	19, // 5: codewalker.v1.SessionReady.steps:type_name -> codewalker.v1.Step
-	29, // 6: codewalker.v1.SessionReady.glossary:type_name -> codewalker.v1.GlossaryTerm
+	30, // 6: codewalker.v1.SessionReady.glossary:type_name -> codewalker.v1.GlossaryTerm
 	18, // 7: codewalker.v1.ListSessionsResponse.sessions:type_name -> codewalker.v1.SessionSummary
 	0,  // 8: codewalker.v1.SessionSummary.kind:type_name -> codewalker.v1.SessionKind
 	22, // 9: codewalker.v1.Step.span:type_name -> codewalker.v1.SourceSpan
 	20, // 10: codewalker.v1.Step.edges:type_name -> codewalker.v1.StepEdge
 	1,  // 11: codewalker.v1.Step.kind:type_name -> codewalker.v1.StepKind
-	35, // 12: codewalker.v1.Step.hunk_span:type_name -> codewalker.v1.HunkSpan
+	36, // 12: codewalker.v1.Step.hunk_span:type_name -> codewalker.v1.HunkSpan
 	2,  // 13: codewalker.v1.StepEdge.label:type_name -> codewalker.v1.EdgeLabel
 	21, // 14: codewalker.v1.StepEdge.external_call_info:type_name -> codewalker.v1.ExternalCallInfo
 	3,  // 15: codewalker.v1.NavigateRequest.direction:type_name -> codewalker.v1.SimpleDirection
 	2,  // 16: codewalker.v1.NavigateRequest.follow_edge:type_name -> codewalker.v1.EdgeLabel
-	25, // 17: codewalker.v1.NarrateEvent.token:type_name -> codewalker.v1.NarrateToken
-	26, // 18: codewalker.v1.NarrateEvent.complete:type_name -> codewalker.v1.StepComplete
-	36, // 19: codewalker.v1.NarrateEvent.error:type_name -> codewalker.v1.ServiceError
-	29, // 20: codewalker.v1.StepComplete.new_terms:type_name -> codewalker.v1.GlossaryTerm
-	20, // 21: codewalker.v1.StepComplete.available_edges:type_name -> codewalker.v1.StepEdge
-	27, // 22: codewalker.v1.StepComplete.summary:type_name -> codewalker.v1.StepSummary
-	4,  // 23: codewalker.v1.RephraseRequest.mode:type_name -> codewalker.v1.RephraseMode
-	5,  // 24: codewalker.v1.GlossaryTerm.kind:type_name -> codewalker.v1.TermKind
-	8,  // 25: codewalker.v1.OpenReviewSessionRequest.experience_level:type_name -> codewalker.v1.ExperienceLevel
-	33, // 26: codewalker.v1.ReviewReady.forge_context:type_name -> codewalker.v1.ForgeContext
-	19, // 27: codewalker.v1.ReviewReady.steps:type_name -> codewalker.v1.Step
-	29, // 28: codewalker.v1.ReviewReady.glossary:type_name -> codewalker.v1.GlossaryTerm
-	6,  // 29: codewalker.v1.ForgeContext.kind:type_name -> codewalker.v1.ForgeContextKind
-	34, // 30: codewalker.v1.ForgeContext.files:type_name -> codewalker.v1.ReviewFile
-	7,  // 31: codewalker.v1.ReviewFile.change:type_name -> codewalker.v1.ChangeKind
-	9,  // 32: codewalker.v1.ServiceError.code:type_name -> codewalker.v1.ErrorCode
-	41, // 33: codewalker.v1.ListFileOrderersResponse.orderers:type_name -> codewalker.v1.FileOrderer
-	44, // 34: codewalker.v1.ListPullRequestsResponse.pull_requests:type_name -> codewalker.v1.PullRequestSummary
-	37, // 35: codewalker.v1.CodeWalker.GetVersion:input_type -> codewalker.v1.GetVersionRequest
-	10, // 36: codewalker.v1.CodeWalker.OpenSession:input_type -> codewalker.v1.OpenSessionRequest
-	23, // 37: codewalker.v1.CodeWalker.Navigate:input_type -> codewalker.v1.NavigateRequest
-	28, // 38: codewalker.v1.CodeWalker.Rephrase:input_type -> codewalker.v1.RephraseRequest
-	30, // 39: codewalker.v1.CodeWalker.ExpandTerm:input_type -> codewalker.v1.ExpandTermRequest
-	14, // 40: codewalker.v1.CodeWalker.CloseSession:input_type -> codewalker.v1.CloseSessionRequest
-	16, // 41: codewalker.v1.CodeWalker.ListSessions:input_type -> codewalker.v1.ListSessionsRequest
-	31, // 42: codewalker.v1.CodeWalker.OpenReviewSession:input_type -> codewalker.v1.OpenReviewSessionRequest
-	39, // 43: codewalker.v1.CodeWalker.ListFileOrderers:input_type -> codewalker.v1.ListFileOrderersRequest
-	42, // 44: codewalker.v1.CodeWalker.ListPullRequests:input_type -> codewalker.v1.ListPullRequestsRequest
-	45, // 45: codewalker.v1.CodeWalker.FetchFileAtRef:input_type -> codewalker.v1.FetchFileAtRefRequest
-	38, // 46: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
-	11, // 47: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
-	24, // 48: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
-	24, // 49: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
-	24, // 50: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
-	15, // 51: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
-	17, // 52: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
-	11, // 53: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
-	40, // 54: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
-	43, // 55: codewalker.v1.CodeWalker.ListPullRequests:output_type -> codewalker.v1.ListPullRequestsResponse
-	46, // 56: codewalker.v1.CodeWalker.FetchFileAtRef:output_type -> codewalker.v1.FetchFileAtRefResponse
-	46, // [46:57] is the sub-list for method output_type
-	35, // [35:46] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	26, // 17: codewalker.v1.NarrateEvent.token:type_name -> codewalker.v1.NarrateToken
+	27, // 18: codewalker.v1.NarrateEvent.complete:type_name -> codewalker.v1.StepComplete
+	37, // 19: codewalker.v1.NarrateEvent.error:type_name -> codewalker.v1.ServiceError
+	25, // 20: codewalker.v1.NarrateEvent.summary_ready:type_name -> codewalker.v1.SummaryReady
+	28, // 21: codewalker.v1.SummaryReady.summary:type_name -> codewalker.v1.StepSummary
+	30, // 22: codewalker.v1.StepComplete.new_terms:type_name -> codewalker.v1.GlossaryTerm
+	20, // 23: codewalker.v1.StepComplete.available_edges:type_name -> codewalker.v1.StepEdge
+	28, // 24: codewalker.v1.StepComplete.summary:type_name -> codewalker.v1.StepSummary
+	4,  // 25: codewalker.v1.RephraseRequest.mode:type_name -> codewalker.v1.RephraseMode
+	5,  // 26: codewalker.v1.GlossaryTerm.kind:type_name -> codewalker.v1.TermKind
+	8,  // 27: codewalker.v1.OpenReviewSessionRequest.experience_level:type_name -> codewalker.v1.ExperienceLevel
+	34, // 28: codewalker.v1.ReviewReady.forge_context:type_name -> codewalker.v1.ForgeContext
+	19, // 29: codewalker.v1.ReviewReady.steps:type_name -> codewalker.v1.Step
+	30, // 30: codewalker.v1.ReviewReady.glossary:type_name -> codewalker.v1.GlossaryTerm
+	6,  // 31: codewalker.v1.ForgeContext.kind:type_name -> codewalker.v1.ForgeContextKind
+	35, // 32: codewalker.v1.ForgeContext.files:type_name -> codewalker.v1.ReviewFile
+	7,  // 33: codewalker.v1.ReviewFile.change:type_name -> codewalker.v1.ChangeKind
+	9,  // 34: codewalker.v1.ServiceError.code:type_name -> codewalker.v1.ErrorCode
+	42, // 35: codewalker.v1.ListFileOrderersResponse.orderers:type_name -> codewalker.v1.FileOrderer
+	45, // 36: codewalker.v1.ListPullRequestsResponse.pull_requests:type_name -> codewalker.v1.PullRequestSummary
+	38, // 37: codewalker.v1.CodeWalker.GetVersion:input_type -> codewalker.v1.GetVersionRequest
+	10, // 38: codewalker.v1.CodeWalker.OpenSession:input_type -> codewalker.v1.OpenSessionRequest
+	23, // 39: codewalker.v1.CodeWalker.Navigate:input_type -> codewalker.v1.NavigateRequest
+	29, // 40: codewalker.v1.CodeWalker.Rephrase:input_type -> codewalker.v1.RephraseRequest
+	31, // 41: codewalker.v1.CodeWalker.ExpandTerm:input_type -> codewalker.v1.ExpandTermRequest
+	14, // 42: codewalker.v1.CodeWalker.CloseSession:input_type -> codewalker.v1.CloseSessionRequest
+	16, // 43: codewalker.v1.CodeWalker.ListSessions:input_type -> codewalker.v1.ListSessionsRequest
+	32, // 44: codewalker.v1.CodeWalker.OpenReviewSession:input_type -> codewalker.v1.OpenReviewSessionRequest
+	40, // 45: codewalker.v1.CodeWalker.ListFileOrderers:input_type -> codewalker.v1.ListFileOrderersRequest
+	43, // 46: codewalker.v1.CodeWalker.ListPullRequests:input_type -> codewalker.v1.ListPullRequestsRequest
+	46, // 47: codewalker.v1.CodeWalker.FetchFileAtRef:input_type -> codewalker.v1.FetchFileAtRefRequest
+	39, // 48: codewalker.v1.CodeWalker.GetVersion:output_type -> codewalker.v1.GetVersionResponse
+	11, // 49: codewalker.v1.CodeWalker.OpenSession:output_type -> codewalker.v1.SessionEvent
+	24, // 50: codewalker.v1.CodeWalker.Navigate:output_type -> codewalker.v1.NarrateEvent
+	24, // 51: codewalker.v1.CodeWalker.Rephrase:output_type -> codewalker.v1.NarrateEvent
+	24, // 52: codewalker.v1.CodeWalker.ExpandTerm:output_type -> codewalker.v1.NarrateEvent
+	15, // 53: codewalker.v1.CodeWalker.CloseSession:output_type -> codewalker.v1.CloseSessionResponse
+	17, // 54: codewalker.v1.CodeWalker.ListSessions:output_type -> codewalker.v1.ListSessionsResponse
+	11, // 55: codewalker.v1.CodeWalker.OpenReviewSession:output_type -> codewalker.v1.SessionEvent
+	41, // 56: codewalker.v1.CodeWalker.ListFileOrderers:output_type -> codewalker.v1.ListFileOrderersResponse
+	44, // 57: codewalker.v1.CodeWalker.ListPullRequests:output_type -> codewalker.v1.ListPullRequestsResponse
+	47, // 58: codewalker.v1.CodeWalker.FetchFileAtRef:output_type -> codewalker.v1.FetchFileAtRefResponse
+	48, // [48:59] is the sub-list for method output_type
+	37, // [37:48] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_codewalker_v1_codewalker_proto_init() }
@@ -3763,6 +3834,7 @@ func file_codewalker_v1_codewalker_proto_init() {
 		(*NarrateEvent_Token)(nil),
 		(*NarrateEvent_Complete)(nil),
 		(*NarrateEvent_Error)(nil),
+		(*NarrateEvent_SummaryReady)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3770,7 +3842,7 @@ func file_codewalker_v1_codewalker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_codewalker_v1_codewalker_proto_rawDesc), len(file_codewalker_v1_codewalker_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   37,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/codewalker/v1/codewalker.proto
+++ b/proto/codewalker/v1/codewalker.proto
@@ -266,10 +266,20 @@ enum SimpleDirection {
 // Streamed back for Navigate, Rephrase, and ExpandTerm.
 message NarrateEvent {
   oneof event {
-    NarrateToken    token    = 1; // Streaming LLM token
-    StepComplete    complete = 2; // Final event for this narration
-    ServiceError    error    = 3;
+    NarrateToken    token         = 1; // Streaming LLM token
+    StepComplete    complete      = 2; // Final event for this narration
+    ServiceError    error         = 3;
+    SummaryReady    summary_ready = 4; // Structured summary, sent as soon as available
   }
+}
+
+// Emitted by Navigate as soon as the structured summary is available, which is
+// typically before narration tokens finish streaming. New clients should
+// prefer this over reading StepComplete.summary so the summary can render
+// without waiting for the full narration stream. StepComplete.summary
+// continues to be populated for backward compatibility.
+message SummaryReady {
+  StepSummary summary = 1;
 }
 
 message NarrateToken {

--- a/server/navigate.go
+++ b/server/navigate.go
@@ -109,24 +109,34 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 	slog.Debug("narration started", "step_id", step.ID)
 
 	tokenCount := 0
-	for token := range tokens {
+	var summaryProto *v1.StepSummary
+
+	// Drain tokens and the summary channel concurrently so the structured
+	// summary can be sent the moment it is ready, without waiting for
+	// narration to finish. Setting tokens or summaryCh to nil after either
+	// is exhausted removes that case from the select (a nil channel blocks
+	// forever), letting the loop exit when both are done.
+	tokenCh := tokens
+	for tokenCh != nil || summaryCh != nil {
 		select {
 		case <-ctx.Done():
 			return status.FromContextError(ctx.Err()).Err()
-		default:
-		}
-		tokenCount++
-		if err := stream.Send(&v1.NarrateEvent{
-			Event: &v1.NarrateEvent_Token{Token: &v1.NarrateToken{Text: token}},
-		}); err != nil {
-			return err
-		}
-	}
-	slog.Debug("narration complete", "step_id", step.ID, "token_count", tokenCount)
-
-	var summaryProto *v1.StepSummary
-	if summaryCh != nil {
-		if summary := <-summaryCh; summary != nil {
+		case token, ok := <-tokenCh:
+			if !ok {
+				tokenCh = nil
+				continue
+			}
+			tokenCount++
+			if err := stream.Send(&v1.NarrateEvent{
+				Event: &v1.NarrateEvent_Token{Token: &v1.NarrateToken{Text: token}},
+			}); err != nil {
+				return err
+			}
+		case summary := <-summaryCh:
+			summaryCh = nil
+			if summary == nil {
+				continue
+			}
 			summaryProto = &v1.StepSummary{
 				Breaking:      summary.Breaking,
 				Risk:          summary.Risk,
@@ -137,8 +147,16 @@ func (s *Server) Navigate(req *v1.NavigateRequest, stream v1.CodeWalker_Navigate
 				Suggestion:    summary.Suggestion,
 				Confidence:    summary.Confidence,
 			}
+			if err := stream.Send(&v1.NarrateEvent{
+				Event: &v1.NarrateEvent_SummaryReady{
+					SummaryReady: &v1.SummaryReady{Summary: summaryProto},
+				},
+			}); err != nil {
+				return err
+			}
 		}
 	}
+	slog.Debug("narration complete", "step_id", step.ID, "token_count", tokenCount)
 
 	return stream.Send(&v1.NarrateEvent{
 		Event: &v1.NarrateEvent_Complete{

--- a/server/navigate_summary_test.go
+++ b/server/navigate_summary_test.go
@@ -1,0 +1,322 @@
+package server_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/yourorg/codewalker/gen/codewalker/v1"
+	"github.com/yourorg/codewalker/internal/graph"
+	"github.com/yourorg/codewalker/internal/llm"
+	"github.com/yourorg/codewalker/internal/session"
+	"github.com/yourorg/codewalker/server"
+	"google.golang.org/grpc/metadata"
+)
+
+// summaryProvider is a controllable provider used to drive ordering tests for
+// the Navigate stream. Tokens are fed via the tokens channel (the test pushes
+// and closes it). GenerateStepSummary blocks until summaryReady is closed.
+type summaryProvider struct {
+	tokens       chan string
+	summary      *llm.StepSummary
+	summaryReady chan struct{}
+}
+
+func (p *summaryProvider) Narrate(_ context.Context, _ llm.NarrateRequest) (<-chan string, error) {
+	return p.tokens, nil
+}
+
+func (p *summaryProvider) Rephrase(_ context.Context, _ llm.RephraseRequest) (<-chan string, error) {
+	ch := make(chan string)
+	close(ch)
+	return ch, nil
+}
+
+func (p *summaryProvider) SummarizeExternalCall(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (p *summaryProvider) ExtractGlossaryTerms(_ context.Context, _ llm.GlossaryRequest) ([]llm.GlossaryCandidate, error) {
+	return nil, nil
+}
+
+func (p *summaryProvider) ExpandTerm(_ context.Context, _ llm.ExpandTermRequest) (<-chan string, error) {
+	ch := make(chan string)
+	close(ch)
+	return ch, nil
+}
+
+func (p *summaryProvider) GenerateStepSummary(ctx context.Context, _ llm.SummaryRequest) (*llm.StepSummary, error) {
+	select {
+	case <-p.summaryReady:
+		return p.summary, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// recordingNarrateStream is a thread-safe stream so the test goroutine can
+// observe events while Navigate is still streaming on another.
+type recordingNarrateStream struct {
+	ctx    context.Context
+	mu     sync.Mutex
+	events []*v1.NarrateEvent
+}
+
+func (s *recordingNarrateStream) Send(e *v1.NarrateEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+	return nil
+}
+func (s *recordingNarrateStream) Context() context.Context     { return s.ctx }
+func (s *recordingNarrateStream) SetHeader(metadata.MD) error  { return nil }
+func (s *recordingNarrateStream) SendHeader(metadata.MD) error { return nil }
+func (s *recordingNarrateStream) SetTrailer(metadata.MD)       {}
+func (s *recordingNarrateStream) SendMsg(any) error            { return nil }
+func (s *recordingNarrateStream) RecvMsg(any) error            { return nil }
+
+func (s *recordingNarrateStream) snapshot() []*v1.NarrateEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*v1.NarrateEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func reviewSessionWithHunkStep(t *testing.T, store *session.Store, id string) {
+	t.Helper()
+	g := graph.NewGraph()
+	step := &graph.Step{
+		ID:    "hunk:foo.go:1",
+		Label: "foo.go:1",
+		Kind:  v1.StepKind_STEP_KIND_HUNK,
+		HunkSpan: &v1.HunkSpan{
+			FilePath: "foo.go",
+			NewStart: 1,
+			NewLines: 1,
+			RawDiff:  "@@ -1 +1 @@\n-old\n+new\n",
+		},
+	}
+	g.Add(step)
+	g.EntryID = step.ID
+	sess := session.New(id, g, 5, "diff", false, nil, "", "", "")
+	sess.Kind = v1.SessionKind_SESSION_KIND_REVIEW
+	store.Set(sess)
+}
+
+func walkthroughSessionWithSourceStep(t *testing.T, store *session.Store, id string) {
+	t.Helper()
+	g := graph.NewGraph()
+	step := &graph.Step{
+		ID:    "step:1",
+		Label: "function entry",
+		Kind:  v1.StepKind_STEP_KIND_ENTRY,
+		Source: &v1.SourceSpan{
+			StartLine: 1,
+			EndLine:   1,
+			RawSource: "package main",
+		},
+	}
+	g.Add(step)
+	g.EntryID = step.ID
+	sess := session.New(id, g, 5, "go", false, []byte("package main\n"), "main.go", "/repo", "HEAD")
+	sess.Kind = v1.SessionKind_SESSION_KIND_WALKTHROUGH
+	store.Set(sess)
+}
+
+func TestNavigate_ReviewSession_SummaryReadyBeforeComplete(t *testing.T) {
+	store := session.NewStore()
+	const sessID = "review-test-1"
+	reviewSessionWithHunkStep(t, store, sessID)
+
+	tokens := make(chan string, 3)
+	tokens <- "alpha"
+	tokens <- "beta"
+	tokens <- "gamma"
+	close(tokens)
+
+	summaryReady := make(chan struct{})
+	close(summaryReady)
+
+	provider := &summaryProvider{
+		tokens:       tokens,
+		summary:      &llm.StepSummary{Breaking: "No", WhatChanged: "test"},
+		summaryReady: summaryReady,
+	}
+	srv := server.New(store, provider, "")
+
+	stream := &recordingNarrateStream{ctx: context.Background()}
+	err := srv.Navigate(&v1.NavigateRequest{
+		SessionId:   sessID,
+		Destination: &v1.NavigateRequest_StepId{StepId: "hunk:foo.go:1"},
+	}, stream)
+	if err != nil {
+		t.Fatalf("Navigate: %v", err)
+	}
+
+	events := stream.snapshot()
+	summaryIdx, completeIdx := -1, -1
+	for i, e := range events {
+		if e.GetSummaryReady() != nil {
+			if summaryIdx != -1 {
+				t.Errorf("multiple SummaryReady events; second at index %d", i)
+			}
+			summaryIdx = i
+		}
+		if e.GetComplete() != nil {
+			completeIdx = i
+		}
+	}
+	if summaryIdx == -1 {
+		t.Fatal("no SummaryReady event emitted for review-session step")
+	}
+	if completeIdx == -1 {
+		t.Fatal("no Complete event emitted")
+	}
+	if summaryIdx >= completeIdx {
+		t.Errorf("SummaryReady (idx %d) must precede Complete (idx %d)", summaryIdx, completeIdx)
+	}
+
+	sr := events[summaryIdx].GetSummaryReady()
+	if sr.Summary == nil || sr.Summary.WhatChanged != "test" {
+		t.Errorf("SummaryReady.summary unexpected: %+v", sr.Summary)
+	}
+
+	// Back-compat: Complete.summary still populated with the same data.
+	c := events[completeIdx].GetComplete()
+	if c.Summary == nil || c.Summary.WhatChanged != "test" {
+		t.Errorf("Complete.summary back-compat: got %+v", c.Summary)
+	}
+}
+
+func TestNavigate_ReviewSession_SummaryEmittedBeforeNarrationFinishes(t *testing.T) {
+	store := session.NewStore()
+	const sessID = "review-test-2"
+	reviewSessionWithHunkStep(t, store, sessID)
+
+	// Tokens channel is unbuffered. The test pushes only after observing
+	// SummaryReady, proving the summary did not block behind narration.
+	tokens := make(chan string)
+	summaryReady := make(chan struct{})
+	close(summaryReady) // summary returns immediately
+
+	provider := &summaryProvider{
+		tokens:       tokens,
+		summary:      &llm.StepSummary{Breaking: "No", WhatChanged: "interleaved"},
+		summaryReady: summaryReady,
+	}
+	srv := server.New(store, provider, "")
+
+	stream := &recordingNarrateStream{ctx: context.Background()}
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Navigate(&v1.NavigateRequest{
+			SessionId:   sessID,
+			Destination: &v1.NavigateRequest_StepId{StepId: "hunk:foo.go:1"},
+		}, stream)
+	}()
+
+	if !waitForEvent(stream, 2*time.Second, func(e *v1.NarrateEvent) bool {
+		return e.GetSummaryReady() != nil
+	}) {
+		t.Fatal("SummaryReady was not emitted before tokens were pushed")
+	}
+
+	// Now push narration and let Navigate finish.
+	tokens <- "after-summary-1"
+	tokens <- "after-summary-2"
+	close(tokens)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Navigate: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Navigate did not return")
+	}
+
+	events := stream.snapshot()
+	if len(events) == 0 || events[0].GetSummaryReady() == nil {
+		t.Fatalf("first event should be SummaryReady; got %d events", len(events))
+	}
+	if last := events[len(events)-1]; last.GetComplete() == nil {
+		t.Errorf("last event should be Complete; got %T", last.Event)
+	}
+}
+
+func TestNavigate_WalkthroughStep_NoSummaryReady(t *testing.T) {
+	store := session.NewStore()
+	const sessID = "walk-test-1"
+	walkthroughSessionWithSourceStep(t, store, sessID)
+
+	tokens := make(chan string, 1)
+	tokens <- "narration"
+	close(tokens)
+
+	// summaryReady is never closed. For walkthrough steps navigate.go must
+	// not start the summary goroutine, so this should not block.
+	provider := &summaryProvider{
+		tokens:       tokens,
+		summary:      nil,
+		summaryReady: make(chan struct{}),
+	}
+	srv := server.New(store, provider, "")
+
+	stream := &recordingNarrateStream{ctx: context.Background()}
+	if err := srv.Navigate(&v1.NavigateRequest{
+		SessionId:   sessID,
+		Destination: &v1.NavigateRequest_StepId{StepId: "step:1"},
+	}, stream); err != nil {
+		t.Fatalf("Navigate: %v", err)
+	}
+
+	events := stream.snapshot()
+	for _, e := range events {
+		if e.GetSummaryReady() != nil {
+			t.Fatal("walkthrough step emitted SummaryReady; expected none")
+		}
+	}
+	if last := events[len(events)-1]; last.GetComplete() == nil {
+		t.Fatalf("last event should be Complete; got %T", last.Event)
+	}
+	if c := events[len(events)-1].GetComplete(); c.Summary != nil {
+		t.Errorf("walkthrough Complete.summary should be nil; got %+v", c.Summary)
+	}
+}
+
+func TestOpenReviewSession_GlossaryEmpty(t *testing.T) {
+	store := session.NewStore()
+	srv := server.New(store, &mockProvider{}, "")
+
+	stream := &mockSessionStream{ctx: context.Background()}
+	if err := srv.OpenReviewSession(&v1.OpenReviewSessionRequest{
+		Url: "https://test.example.com/owner/repo/pull/1",
+	}, stream); err != nil {
+		t.Fatalf("OpenReviewSession: %v", err)
+	}
+
+	rr := stream.events[len(stream.events)-1].GetReviewReady()
+	if rr == nil {
+		t.Fatal("no ReviewReady event")
+	}
+	if len(rr.Glossary) != 0 {
+		t.Errorf("ReviewReady.glossary should be empty; got %d terms", len(rr.Glossary))
+	}
+}
+
+// waitForEvent polls stream until pred matches an event or timeout elapses.
+func waitForEvent(stream *recordingNarrateStream, timeout time.Duration, pred func(*v1.NarrateEvent) bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, e := range stream.snapshot() {
+			if pred(e) {
+				return true
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}

--- a/server/open_review_session.go
+++ b/server/open_review_session.go
@@ -12,7 +12,6 @@ import (
 	_ "github.com/yourorg/codewalker/internal/forge/forges"
 	_ "github.com/yourorg/codewalker/internal/forge/orderers"
 	"github.com/yourorg/codewalker/internal/graph"
-	"github.com/yourorg/codewalker/internal/llm"
 	"github.com/yourorg/codewalker/internal/session"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -93,58 +92,24 @@ func (s *Server) OpenReviewSession(req *v1.OpenReviewSessionRequest, stream v1.C
 	g, fileEntryStepIDs, orderedStepIDs := buildHunkGraph(payload.Files, fileLines, req.OmitRawSource)
 	slog.Debug("hunk graph built", "step_count", g.Len(), "entry_step_id", g.EntryID)
 
-	// --- Step 4: extract glossary ---
-	if err := send(stream, progress("extracting glossary", 75)); err != nil {
+	// --- Step 4: create session ---
+	// Glossary extraction was removed: the only client that consumed
+	// ReviewReady.glossary never read it, and the LLM call added several
+	// seconds of latency to session open. The proto field is retained for
+	// backward compatibility but is now always empty.
+	if err := send(stream, progress("creating session", 90)); err != nil {
 		return err
 	}
 
 	effectiveLevel := session.EffectiveLevel(req.ExperienceLevel)
 
-	var diffSample strings.Builder
-	if fc.PRDescription != "" {
-		diffSample.WriteString(fc.PRDescription)
-		diffSample.WriteString("\n\n")
-	}
-outer:
-	for _, f := range payload.Files {
-		for _, h := range f.Hunks {
-			diffSample.WriteString(h.RawDiff)
-			if diffSample.Len() > 4096 {
-				break outer
-			}
-		}
-	}
-
-	glossaryCandidates, _ := s.provider.ExtractGlossaryTerms(ctx, llm.GlossaryRequest{
-		Code:     diffSample.String(),
-		Language: "diff",
-		Level:    effectiveLevel,
-	})
-	slog.Debug("glossary extracted", "term_count", len(glossaryCandidates))
-
-	// --- Step 5: create session ---
-	if err := send(stream, progress("creating session", 90)); err != nil {
-		return err
-	}
-
 	sessID := newSessionID()
 	sess := session.New(sessID, g, effectiveLevel, "diff", req.OmitRawSource, nil, "", "", "")
 	sess.Kind = v1.SessionKind_SESSION_KIND_REVIEW
 
-	glossaryProto := make([]*v1.GlossaryTerm, 0, len(glossaryCandidates))
-	for _, c := range glossaryCandidates {
-		t := &v1.GlossaryTerm{
-			Term:   c.Term,
-			Kind:   termKindFromString(c.Kind),
-			StepId: g.EntryID,
-		}
-		sess.AddGlossaryTerm(t)
-		glossaryProto = append(glossaryProto, t)
-	}
-
 	s.store.Set(sess)
 
-	// --- Step 6: emit ReviewReady ---
+	// --- Step 5: emit ReviewReady ---
 	forgeCtxProto := toProtoForgeContext(fc, payload.Files, fileEntryStepIDs)
 	steps := protoReviewSteps(g, orderedStepIDs)
 
@@ -154,7 +119,6 @@ outer:
 				SessionId:      sessID,
 				ForgeContext:   forgeCtxProto,
 				Steps:          steps,
-				Glossary:       glossaryProto,
 				TotalSteps:     uint32(g.Len()),
 				EntryStepId:    g.EntryID,
 				EffectiveLevel: uint32(effectiveLevel),


### PR DESCRIPTION
Closes #62.

## Summary

- Adds `NarrateEvent.summary_ready` (field 4 of the oneof) so `Navigate` can emit the structured summary as soon as it is ready, rather than holding it back until narration finishes streaming. The terminal `Complete.summary` continues to be populated, so old clients keep working unchanged.
- Reworks `server/navigate.go` to drain the narration token channel and the summary channel concurrently via `select`, using the nil-channel idiom to drop each case once exhausted. `ctx.Done()` is still observed in the loop.
- Removes the glossary LLM call from `OpenReviewSession`. The only consumer never read `ReviewReady.glossary`, and the call added several seconds of latency at session open. The proto field is retained for backward compatibility but is now always empty.
- Updates `codewalker-briefing.md` to document the new event ordering and to record that review-session glossary is no longer produced.

## Tests

New tests in `server/navigate_summary_test.go`:

- `TestNavigate_ReviewSession_SummaryReadyBeforeComplete` — for a hunk step with summary returning instantly and three buffered tokens, asserts a single `SummaryReady` event precedes `Complete`, both carry the same summary payload (back-compat).
- `TestNavigate_ReviewSession_SummaryEmittedBeforeNarrationFinishes` — narration channel is unbuffered and only fed after the test observes `SummaryReady` on the wire, proving the summary is not blocked behind narration.
- `TestNavigate_WalkthroughStep_NoSummaryReady` — a walkthrough step (no `HunkSpan`) emits no `SummaryReady`; `Complete.summary` is nil.
- `TestOpenReviewSession_GlossaryEmpty` — `ReviewReady.glossary` is empty after the change.

`make ci` passes.

## Test plan

- [x] `make ci` passes locally
- [x] New SummaryReady ordering tests pass
- [x] Existing review-session and walkthrough tests still pass
- [ ] Tag `v0.7.0` after merge so JitPack builds the new proto stubs (owner action — Claude can't tag)

https://claude.ai/code/session_01HK99yD6ACxwnpAgrTJgqPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK99yD6ACxwnpAgrTJgqPR)_